### PR TITLE
Bloxa V0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ The bulk capacitor bank is formed with 3 [180 µF aluminum electrolytic capacito
 
 The overcurrent protection trip value is set to 35 A. 
 
+## Release notes
+Newest entries at the top.
+### Bloxa V0.2
+* Current shunts replaced (5 mOhms replaced with 10 mOhms)
+* Overcurrent protection added. Itrip is ~35 A.
+* RCPWM through-hole connector replaced with smd solder pads.
+* Power loss estimations table added to the schematic
+* TVS diode (D1) replaced with one that has lower breaksdown voltage.
+
 ## License
 
 This project is licensed under the terms of [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Zubax Bloxa is arguably the most compact practical ESC design based on the Mitoc
 * Compatible with the [UAVCAN hardware design recommendations](https://uavcan.org/specification)
 
 <img src="pics/bloxa.png" alt="Bloxa top"  width = "100%" />
-  
+
 ## Brief specs
 
 * Operating voltage range 4-8S Li-ion (LiCoO<sub>2</sub>) battery (12-34 V)
@@ -25,10 +25,9 @@ The main advantage of Bloxa is its miniature size. To achieve it, a novel Mitoch
 <p align="center">
 <img src="pics/construction.png"  width = "50%"/>
 </p>
-
-Mitochondrik is mounted on the power stage PCB using an intermediary 2mm thick PCB that basically serves as a connector.
+Mitochondrik is mounted on the power stage PCB using an intermediary 2 mm thick PCB that basically serves as a connector.
 Soldering is done using the edge connectors on the Mitochondrik, the intermediary  PCB, and the power stage PCB in the plane perpendicular to the PCB planes. 
-Also, one of the RF shields on the Mitochondrik had to be removed (please contact Zubax Robotics for ordering).
+Also, one of the RF shields on the Mitochondrik had to be removed (compatible Mitochondrik modules are available upon request, please contact Zubax Robotics).
 
 High-reliability designs may prefer to avoid such unconventional approaches to ensure predictable mechanical characteristics.
 

--- a/bloxa.brd
+++ b/bloxa.brd
@@ -24,17 +24,17 @@
 <layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
 <layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
 <layer number="15" name="gnd" color="4" fill="6" visible="no" active="yes"/>
-<layer number="16" name="Bottom" color="9" fill="1" visible="no" active="yes"/>
+<layer number="16" name="Bottom" color="9" fill="1" visible="yes" active="yes"/>
 <layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="20" name="Dimension" color="15" fill="1" visible="yes" active="yes"/>
 <layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="yes"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
 <layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
 <layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
@@ -60,7 +60,7 @@
 <layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
 <layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="yes"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
 <layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
@@ -166,7 +166,7 @@
 <layer number="255" name="routoute" color="7" fill="1" visible="no" active="yes"/>
 </layers>
 <board>
-<fusionsync huburn="a.cGVyc29uYWw6dWUyYWE4ZDY4" projecturn="a.cGVyc29uYWw6dWUyYWE4ZDY4IzIwMTgxMjA2MTY0MTQ2ODgx" f3durn="urn:adsk.wipprod:dm.lineage:vsyq4vMaSZ2FqqpQV7bhuQ" pcbguid="4b14bc76-6846-4836-9cfe-c4d4cdaa648d" lastpulledtime="" lastsyncedchangeguid="bc218286-cd5a-fab4-683b-a2897ab19400" latestrevisionid="" lastsyncedrevisionid="" lastboardhashguid="" lastpushedtime="" linktopcb3d="%12"/>
+<fusionsync huburn="a.cGVyc29uYWw6dWUyYWE4ZDY4" projecturn="a.cGVyc29uYWw6dWUyYWE4ZDY4IzIwMTkwOTA2MjEzMTk3ODU2" f3durn="urn:adsk.wipprod:dm.lineage:t_abUf3MRzCdrWzT1gwKmQ" pcbguid="9a6ced3b-19a8-49ab-9ca9-3537635eed02" lastpulledtime="" lastsyncedchangeguid="" latestrevisionid="" lastsyncedrevisionid="" lastboardhashguid="9fee249a-4e12-b9c1-755d-a6b3befaaa10" lastpushedtime="2020-03-30T16:11:42Z" linktopcb3d="%12"/>
 <plain>
 <wire x1="-10.95" y1="-14.95" x2="10.95" y2="-14.95" width="0.01" layer="20" locked="yes"/>
 <wire x1="10.95" y1="-14.95" x2="12.45" y2="-13.45" width="0.01" layer="20" curve="90" locked="yes"/>
@@ -9547,7 +9547,7 @@
 <attributes>
 </attributes>
 <variantdefs>
-<variantdef name="Basic"/>
+<variantdef name="Basic" current="yes"/>
 <variantdef name="nocaps"/>
 </variantdefs>
 <classes>
@@ -9756,47 +9756,47 @@
 </pass>
 </autorouter>
 <elements>
-<element name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-5" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-7" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-9" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="13" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="11" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="9" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="7" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="5" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="3" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="1" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-1" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-3" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-5" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-7" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-9" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-11" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-13" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-9" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-7" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-5" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="3" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="5" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="7" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="9" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-13" smashed="yes" rot="MR0"/>
-<element name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-11" smashed="yes" rot="MR0"/>
-<element name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-9" smashed="yes" rot="MR0"/>
-<element name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-7" smashed="yes" rot="MR0"/>
-<element name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-5" smashed="yes" rot="MR0"/>
-<element name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-3" smashed="yes" rot="MR0"/>
-<element name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-1" smashed="yes" rot="MR0"/>
-<element name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="1" smashed="yes" rot="MR0"/>
-<element name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="3" smashed="yes" rot="MR0"/>
-<element name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="5" smashed="yes" rot="MR0"/>
-<element name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="7" smashed="yes" rot="MR0"/>
-<element name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="9" smashed="yes" rot="MR0"/>
-<element name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="11" smashed="yes" rot="MR0"/>
-<element name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="9" y="14.95" smashed="yes" rot="MR0"/>
-<element name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="7" y="14.95" smashed="yes" rot="MR0"/>
-<element name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="5" y="14.95" smashed="yes" rot="MR0"/>
-<element name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="3" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-5" y="14.95" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-7" y="14.95" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-9" y="14.95" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="13" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="11" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="9" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="7" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="5" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="3" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="1" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-1" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-3" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-5" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-7" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-9" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-11" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-13" locked="yes" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-9" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-7" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-5" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="3" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="5" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="7" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="9" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-13" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-11" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-9" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-7" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-5" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-3" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-1" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="1" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="3" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="5" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="7" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="9" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="11" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="9" y="14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="7" y="14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="5" y="14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="3" y="14.95" populate="no" smashed="yes" rot="MR0"/>
 <element name="C10" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" package="C0402" package3d_urn="urn:adsk.eagle:package:2539379/2" value="0.1µF" x="-9.95" y="-5.05" smashed="yes" rot="R90">
 <attribute name="DIGIKEY#" value="490-3261-1-ND" x="109.05" y="-49.05" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="MANF" value="Murata Electronics North America" x="109.05" y="-49.05" size="1.778" layer="27" rot="R90" display="off"/>
@@ -9924,7 +9924,7 @@
 <attribute name="TOLERANCE" value="1%" x="39.55" y="195.85" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="VALUE" x="-10.45" y="-13.05" size="0.5" layer="27" font="vector" ratio="15" rot="R180" align="center"/>
 </element>
-<element name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="-4" y="17.15" smashed="yes">
+<element name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="-4" y="17.15" populate="no" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="-11" y="24.15" size="1.778" layer="27" display="off"/>
 </element>
 <element name="R4" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="10 mOhms" x="-4.5" y="1.375" locked="yes" smashed="yes">
@@ -9972,7 +9972,7 @@
 <attribute name="TOLERANCE" value="5%" x="-7.05" y="-11.8" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="VALUE" x="-7.95" y="5.2" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="0" y="17.15" smashed="yes" rot="R270">
+<element name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="0" y="17.15" populate="no" smashed="yes" rot="R270">
 <attribute name="BOM" value="EXCLUDE" x="-18" y="27.15" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
 <element name="R10" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="10 mOhms" x="4.5" y="1.375" locked="yes" smashed="yes">
@@ -10002,7 +10002,7 @@
 <attribute name="TOLERANCE" value="5%" x="12.5" y="5.2" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="VALUE" x="1.6" y="5.2" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="4" y="17.15" smashed="yes">
+<element name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="4" y="17.15" populate="no" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="-9" y="-15.85" size="1.778" layer="27" display="off"/>
 </element>
 <element name="R11" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" package="R0402" package3d_urn="urn:adsk.eagle:package:2539512/2" value="4R3" x="8.65" y="5.2" smashed="yes" rot="R90">
@@ -10023,7 +10023,7 @@
 <attribute name="TOLERANCE" value="5%" x="31.3" y="-0.8" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="VALUE" x="10.4" y="5.2" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="S1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="SENSE-0.6" package3d_urn="urn:adsk.eagle:package:7365871/1" value="SENSE" x="9.8" y="3" smashed="yes" rot="MR0">
+<element name="S1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="SENSE-0.6" package3d_urn="urn:adsk.eagle:package:7365871/1" value="SENSE" x="9.8" y="3" populate="no" smashed="yes" rot="MR0">
 <attribute name="BOM" value="EXCLUDE" x="22.8" y="-20" size="1.778" layer="28" rot="MR0" display="off"/>
 </element>
 <element name="C7" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" package="C1210" package3d_urn="urn:adsk.eagle:package:2539380/2" value="10µF" x="-4.6" y="7" smashed="yes" rot="R90">
@@ -10091,10 +10091,10 @@
 <attribute name="NAME" x="9.2" y="10" size="1.5" layer="25" font="vector" ratio="15" rot="R90" align="center"/>
 <attribute name="PACKAGE" value="56LFPAK" x="95.2" y="9" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="PAD43" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="4X2" package3d_urn="urn:adsk.eagle:package:3188708/1" value="PAD-4X2" x="10.5" y="1.4" locked="yes" smashed="yes" rot="R90">
+<element name="PAD43" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="4X2" package3d_urn="urn:adsk.eagle:package:3188708/1" value="PAD-4X2" x="10.5" y="1.4" locked="yes" populate="no" smashed="yes" rot="R90">
 <attribute name="BOM" value="EXCLUDE" x="10.5" y="1.4" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="PAD42" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="4X2" package3d_urn="urn:adsk.eagle:package:3188708/1" value="PAD-4X2" x="-10.5" y="1.4" locked="yes" smashed="yes" rot="R90">
+<element name="PAD42" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="4X2" package3d_urn="urn:adsk.eagle:package:3188708/1" value="PAD-4X2" x="-10.5" y="1.4" locked="yes" populate="no" smashed="yes" rot="R90">
 <attribute name="BOM" value="EXCLUDE" x="-10.5" y="1.4" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
 <element name="D1" library="TVS_diodes" library_urn="urn:adsk.eagle:library:3333632" package="SOD128" package3d_urn="urn:adsk.eagle:package:6533206/2" value="PTVS36VP1UP,115-36V-SOD128" x="6.95" y="-2.85" smashed="yes" rot="R180">
@@ -10147,26 +10147,26 @@
 <attribute name="VALUE" x="-10.475" y="-9.735" size="0.5" layer="27" font="vector" ratio="15" rot="R180" align="bottom-center"/>
 <attribute name="VOLTAGE" value="16V" x="-10.475" y="-9.1" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="J2" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="CONNECTION" package3d_urn="urn:adsk.eagle:package:7439847/1" value="CONNECTION" x="-6.775" y="-7.8" smashed="yes" rot="MR180">
+<element name="J2" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="CONNECTION" package3d_urn="urn:adsk.eagle:package:7439847/1" value="CONNECTION" x="-6.775" y="-7.8" populate="no" smashed="yes" rot="MR180">
 <attribute name="BOM" value="EXCLUDE" x="-6.775" y="-8.325" size="1.778" layer="28" rot="MR180" display="off"/>
 </element>
-<element name="FD2" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="FIDUCIA-MOUNT" value="FIDUCIALMOUNT" x="-3" y="-14.075" smashed="yes">
+<element name="FD2" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="FIDUCIA-MOUNT" value="FIDUCIALMOUNT" x="-3" y="-14.075" populate="no" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="-3" y="-14.075" size="1.778" layer="27" display="off"/>
 </element>
-<element name="FD1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="FIDUCIA-MOUNT" value="FIDUCIALMOUNT" x="11.4" y="17.6" smashed="yes">
+<element name="FD1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="FIDUCIA-MOUNT" value="FIDUCIALMOUNT" x="11.4" y="17.6" populate="no" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="11.4" y="17.6" size="1.778" layer="27" display="off"/>
 </element>
-<element name="J1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="CONNECTION" package3d_urn="urn:adsk.eagle:package:7439847/1" value="CONNECTION" x="10.5" y="-1.2" smashed="yes" rot="MR90">
+<element name="J1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="CONNECTION" package3d_urn="urn:adsk.eagle:package:7439847/1" value="CONNECTION" x="10.5" y="-1.2" populate="no" smashed="yes" rot="MR90">
 <attribute name="BOM" value="EXCLUDE" x="10.5" y="-1.2" size="1.778" layer="28" rot="MR90" display="off"/>
 </element>
-<element name="LED1" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="0402_LED" package3d_urn="urn:adsk.eagle:package:1040216/2" value="GREEN" x="-2.425" y="-14.05" smashed="yes" rot="MR180">
+<element name="LED1" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="0402_LED" package3d_urn="urn:adsk.eagle:package:1040216/2" value="GREEN" x="-2.425" y="-14.05" populate="no" smashed="yes" rot="MR180">
 <attribute name="COLOR" value="GREEN" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="DIGIKEY#" value="511-1652-1-ND" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="MANF" value="Rohm Semiconductor" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="MANF#" value="SML-P11MTT86" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="NAME" x="-2.425" y="-14.05" size="0.5" layer="26" font="vector" ratio="15" rot="MR180" align="center"/>
 </element>
-<element name="LED3" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="LITE_ON_RGB_LED" package3d_urn="urn:adsk.eagle:package:1040199/2" value="LTST-C19HE1WT" x="0.5" y="-13.3" smashed="yes" rot="MR180">
+<element name="LED3" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="LITE_ON_RGB_LED" package3d_urn="urn:adsk.eagle:package:1040199/2" value="LTST-C19HE1WT" x="0.5" y="-13.3" populate="no" smashed="yes" rot="MR180">
 <attribute name="DIGIKEY#" value="160-2162-1-ND" x="0.5" y="-13.3" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="MANF" value="Lite-On Inc" x="0.5" y="-13.3" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="MANF#" value="LTST-C19HE1WT" x="0.5" y="-13.3" size="1.778" layer="28" rot="MR180" display="off"/>
@@ -10701,9 +10701,10 @@
 <signal name="OVERCURRENT_PROTECT_ADJ">
 <contactref element="PAD13" pad="P$1"/>
 <contactref element="R14" pad="2"/>
-<wire x1="12.45" y1="-5" x2="12.175" y2="-5.275" width="0.3" layer="1"/>
+<wire x1="12.45" y1="-5" x2="12.45" y2="-5.2" width="0.3" layer="1"/>
+<wire x1="12.45" y1="-5.2" x2="12.375" y2="-5.275" width="0.3" layer="1"/>
 <wire x1="11.375" y1="-5.275" x2="11.325" y2="-5.325" width="0.3" layer="1"/>
-<wire x1="12.175" y1="-5.275" x2="11.375" y2="-5.275" width="0.3" layer="1"/>
+<wire x1="12.375" y1="-5.275" x2="11.375" y2="-5.275" width="0.3" layer="1"/>
 </signal>
 <signal name="USB+">
 <contactref element="PAD7" pad="P$1"/>
@@ -10751,19 +10752,18 @@
 <wire x1="3.45" y1="-2.125" x2="1.95" y2="-2.125" width="0.15" layer="1"/>
 <wire x1="3.45" y1="-2.125" x2="3.7" y2="-2.375" width="0.15" layer="1"/>
 <wire x1="3.7" y1="-2.375" x2="3.7" y2="-4.05" width="0.15" layer="1"/>
-<wire x1="7.575" y1="-11.325" x2="7.575" y2="-8.7" width="0.15" layer="1"/>
 <wire x1="7.87825" y1="-14.515" x2="7.575" y2="-14.21175" width="0.15" layer="1"/>
-<wire x1="7.575" y1="-11.325" x2="7.575" y2="-14.21175" width="0.15" layer="1"/>
+<wire x1="7.575" y1="-8.7" x2="7.575" y2="-14.21175" width="0.15" layer="1"/>
 <wire x1="9" y1="-14.95" x2="8.565" y2="-14.515" width="0.15" layer="1"/>
 <wire x1="8.565" y1="-14.515" x2="7.87825" y2="-14.515" width="0.15" layer="1"/>
 <wire x1="1.95" y1="-2.125" x2="1.6" y2="-2.475" width="0.15" layer="1"/>
 <wire x1="0.375" y1="-2.475" x2="0.175" y2="-2.675" width="0.15" layer="1"/>
 <wire x1="1.6" y1="-2.475" x2="0.375" y2="-2.475" width="0.15" layer="1"/>
 <wire x1="7.575" y1="-8.7" x2="6.825" y2="-7.95" width="0.15" layer="1"/>
-<wire x1="6.825" y1="-6" x2="5.85" y2="-5.025" width="0.15" layer="1"/>
-<wire x1="5.85" y1="-5.025" x2="4.675" y2="-5.025" width="0.15" layer="1"/>
-<wire x1="4.675" y1="-5.025" x2="3.7" y2="-4.05" width="0.15" layer="1"/>
-<wire x1="6.825" y1="-7.95" x2="6.825" y2="-6" width="0.15" layer="1"/>
+<wire x1="6.825" y1="-6.3" x2="5.35" y2="-4.825" width="0.15" layer="1"/>
+<wire x1="5.35" y1="-4.825" x2="4.475" y2="-4.825" width="0.15" layer="1"/>
+<wire x1="4.475" y1="-4.825" x2="3.7" y2="-4.05" width="0.15" layer="1"/>
+<wire x1="6.825" y1="-7.95" x2="6.825" y2="-6.3" width="0.15" layer="1"/>
 </signal>
 <signal name="PHASE_C_GND">
 <contactref element="PAD36" pad="P$1"/>
@@ -11142,7 +11142,6 @@
 <wire x1="-4.975" y1="-11.825" x2="-2.025" y2="-11.825" width="0.5" layer="1"/>
 <wire x1="-0.6" y1="-10.4" x2="2.525" y2="-10.4" width="0.5" layer="1"/>
 <wire x1="2.525" y1="-10.4" x2="2.625" y2="-10.3" width="0.5" layer="1"/>
-<wire x1="2.625" y1="-10.3" x2="2.625" y2="-9.79" width="0.5" layer="1"/>
 <wire x1="-2.025" y1="-11.825" x2="-0.6" y2="-10.4" width="0.5" layer="1"/>
 <wire x1="2.625" y1="-9.79" x2="2.625" y2="-10.3" width="0.5" layer="1"/>
 <wire x1="7.1" y1="-11.2" x2="6.65" y2="-11.65" width="0.5" layer="1"/>
@@ -11150,11 +11149,11 @@
 <wire x1="3.05" y1="-5.825" x2="1.65" y2="-5.825" width="0.5" layer="1"/>
 <wire x1="2.775" y1="-4.575" x2="2.775" y2="-5.825" width="0.5" layer="1"/>
 <wire x1="2.775" y1="-5.825" x2="4.45" y2="-5.825" width="0.5" layer="1"/>
-<wire x1="6.35" y1="-6.425" x2="6.35" y2="-8.14675625" width="0.5" layer="1"/>
+<wire x1="6.35" y1="-7.025" x2="6.35" y2="-8.14675625" width="0.5" layer="1"/>
 <wire x1="6.35" y1="-8.14675625" x2="7.1" y2="-8.89675625" width="0.5" layer="1"/>
-<wire x1="5.75" y1="-5.825" x2="6.35" y2="-6.425" width="0.5" layer="1"/>
+<wire x1="5.15" y1="-5.825" x2="6.35" y2="-7.025" width="0.5" layer="1"/>
 <wire x1="7.1" y1="-8.89675625" x2="7.1" y2="-11.2" width="0.5" layer="1"/>
-<wire x1="4.45" y1="-5.825" x2="5.75" y2="-5.825" width="0.5" layer="1"/>
+<wire x1="4.45" y1="-5.825" x2="5.15" y2="-5.825" width="0.5" layer="1"/>
 <wire x1="2.625" y1="-10.625" x2="2.625" y2="-10.3" width="0.5" layer="1"/>
 <wire x1="6.65" y1="-11.65" x2="3.65" y2="-11.65" width="0.5" layer="1"/>
 <wire x1="3.65" y1="-11.65" x2="2.625" y2="-10.625" width="0.5" layer="1"/>

--- a/bloxa.brd
+++ b/bloxa.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.3.1">
+<eagle version="9.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -99,6 +99,8 @@
 <layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
 <layer number="117" name="bMeasures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="yes"/>
+<layer number="119" name="KAP_TEKEN" color="7" fill="1" visible="no" active="no"/>
+<layer number="120" name="KAP_MAAT1" color="7" fill="1" visible="no" active="no"/>
 <layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
 <layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
 <layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
@@ -107,9 +109,11 @@
 <layer number="126" name="_bnames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="127" name="_tvalues" color="7" fill="1" visible="no" active="yes"/>
 <layer number="128" name="_bvalues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="129" name="top_silk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="130" name="bLogo" color="7" fill="1" visible="no" active="yes"/>
 <layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
 <layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="133" name="bottom_silk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
 <layer number="145" name="DrillLegend_01-16" color="2" fill="9" visible="no" active="yes"/>
 <layer number="146" name="DrillLegend_01-20" color="3" fill="9" visible="no" active="yes"/>
@@ -162,26 +166,23 @@
 <layer number="255" name="routoute" color="7" fill="1" visible="no" active="yes"/>
 </layers>
 <board>
-<fusionsync huburn="a.cGVyc29uYWw6dWUyYWE4ZDY4" projecturn="a.cGVyc29uYWw6dWUyYWE4ZDY4IzIwMTgxMjA2MTY0MTQ2ODgx" f3durn="urn:adsk.wipprod:dm.lineage:vsyq4vMaSZ2FqqpQV7bhuQ" pcbguid="4b14bc76-6846-4836-9cfe-c4d4cdaa648d" lastpulledtime="" lastsyncedchangeguid="bc218286-cd5a-fab4-683b-a2897ab19400"/>
+<fusionsync huburn="a.cGVyc29uYWw6dWUyYWE4ZDY4" projecturn="a.cGVyc29uYWw6dWUyYWE4ZDY4IzIwMTgxMjA2MTY0MTQ2ODgx" f3durn="urn:adsk.wipprod:dm.lineage:vsyq4vMaSZ2FqqpQV7bhuQ" pcbguid="4b14bc76-6846-4836-9cfe-c4d4cdaa648d" lastpulledtime="" lastsyncedchangeguid="bc218286-cd5a-fab4-683b-a2897ab19400" latestrevisionid="" lastsyncedrevisionid="" lastboardhashguid="" lastpushedtime="" linktopcb3d="%12"/>
 <plain>
 <wire x1="-10.95" y1="-14.95" x2="10.95" y2="-14.95" width="0.01" layer="20" locked="yes"/>
 <wire x1="10.95" y1="-14.95" x2="12.45" y2="-13.45" width="0.01" layer="20" curve="90" locked="yes"/>
 <wire x1="12.45" y1="-13.45" x2="12.45" y2="17.15" width="0.01" layer="20" locked="yes"/>
 <wire x1="12.45" y1="17.15" x2="10.95" y2="18.65" width="0.01" layer="20" curve="90"/>
-<wire x1="10.95" y1="18.65" x2="-10.85" y2="18.65" width="0.01" layer="20"/>
-<wire x1="-10.85" y1="18.65" x2="-10.95" y2="18.65" width="0.01" layer="20"/>
+<wire x1="10.95" y1="18.65" x2="-10.95" y2="18.65" width="0.01" layer="20"/>
 <wire x1="-10.95" y1="18.65" x2="-12.45" y2="17.15" width="0.01" layer="20" curve="90"/>
 <wire x1="-12.45" y1="17.15" x2="-12.45" y2="-13.45" width="0.01" layer="20" locked="yes"/>
 <wire x1="-12.45" y1="-13.45" x2="-10.95" y2="-14.95" width="0.01" layer="20" curve="90" locked="yes"/>
-<text x="-5.25" y="-2.15" size="0.7" layer="1" font="vector" ratio="17" align="bottom-right">BLOXA 0.1</text>
+<text x="-5.25" y="-2.15" size="0.7" layer="1" font="vector" ratio="17" align="bottom-right">BLOXA 0.2</text>
 <text x="-8.35" y="16.8" size="0.6" layer="21" font="vector" ratio="15" align="center">C1</text>
 <text x="0" y="16.025" size="0.6" layer="21" font="vector" ratio="15" align="center">C2</text>
 <text x="8.4" y="16.8" size="0.6" layer="21" font="vector" ratio="15" align="center">C3</text>
 <text x="-6.525" y="17.925" size="0.6" layer="21" font="vector" ratio="15" align="center">+</text>
 <text x="1.8" y="17.25" size="0.6" layer="21" font="vector" ratio="15" align="center">+</text>
 <text x="10.125" y="17.775" size="0.6" layer="21" font="vector" ratio="15" align="center">+</text>
-<text x="14" y="-10" size="1.778" layer="1">Replace CON3 with SMD pads. 
-No TH components allowed here</text>
 </plain>
 <libraries>
 <library name="R_digikey" urn="urn:adsk.eagle:library:2539499">
@@ -247,10 +248,10 @@ No TH components allowed here</text>
 </library>
 <library name="PADS" urn="urn:adsk.eagle:library:3188696">
 <packages>
-<package name="SMD_1X1,5" library_version="8" library_locally_modified="yes">
+<package name="SMD_1X1,5" urn="urn:adsk.eagle:footprint:7879125/1" library_version="21" library_locally_modified="yes">
 <smd name="P$1" x="0" y="0" dx="1" dy="1.5" layer="1" roundness="25" rot="R180"/>
 </package>
-<package name="HOLE_0.6" urn="urn:adsk.eagle:footprint:6513717/1" locally_modified="yes" library_version="8" library_locally_modified="yes">
+<package name="HOLE_0.6" urn="urn:adsk.eagle:footprint:6513717/2" library_version="21" library_locally_modified="yes">
 <pad name="P$1" x="0" y="0" drill="0.6" shape="square"/>
 </package>
 <package name="4X2" urn="urn:adsk.eagle:footprint:3188701/1" library_version="7" library_locally_modified="yes">
@@ -265,13 +266,16 @@ No TH components allowed here</text>
 <wire x1="1.85" y1="1.2" x2="2.2" y2="0.85" width="0.1" layer="21" curve="-90"/>
 <text x="0" y="0" size="1.27" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
-<package name="HOLE_1.5" urn="urn:adsk.eagle:footprint:3332367/2" locally_modified="yes" library_version="8" library_locally_modified="yes">
+<package name="HOLE_1.5" urn="urn:adsk.eagle:footprint:3332367/3" library_version="21" library_locally_modified="yes">
 <pad name="P$1" x="0" y="0" drill="1.5" diameter="2.35"/>
 <text x="0" y="2.54" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
+<package name="1.5X1.5" urn="urn:adsk.eagle:footprint:15477726/1" library_version="21" library_locally_modified="yes">
+<smd name="P$1" x="0" y="0" dx="1.5" dy="1.5" layer="1" roundness="100"/>
+</package>
 </packages>
 <packages3d>
-<package3d name="HOLE_0.6" urn="urn:adsk.eagle:package:6513718/1" locally_modified="yes" type="box" library_version="8" library_locally_modified="yes">
+<package3d name="HOLE_0.6" urn="urn:adsk.eagle:package:6513718/2" type="box" library_version="21" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="HOLE_0.6"/>
 </packageinstances>
@@ -281,9 +285,19 @@ No TH components allowed here</text>
 <packageinstance name="4X2"/>
 </packageinstances>
 </package3d>
-<package3d name="HOLE_1.5" urn="urn:adsk.eagle:package:3332368/2" locally_modified="yes" type="box" library_version="8" library_locally_modified="yes">
+<package3d name="HOLE_1.5" urn="urn:adsk.eagle:package:3332368/3" type="box" library_version="21" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="HOLE_1.5"/>
+</packageinstances>
+</package3d>
+<package3d name="SMD_1X1,5" urn="urn:adsk.eagle:package:7879127/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="SMD_1X1,5"/>
+</packageinstances>
+</package3d>
+<package3d name="1.5X1.5" urn="urn:adsk.eagle:package:15477730/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="1.5X1.5"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -664,6 +678,19 @@ No TH components allowed here</text>
 <wire x1="-4" y1="23.5" x2="4" y2="23.5" width="0.1" layer="51"/>
 <wire x1="4" y1="23.5" x2="4" y2="2" width="0.1" layer="51"/>
 </package>
+<package name="R0402" urn="urn:adsk.eagle:footprint:2539434/1" library_version="46" library_locally_modified="yes">
+<smd name="1" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="2" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="12" align="center">&gt;NAME</text>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
+</package>
 </packages>
 <packages3d>
 <package3d name="RADIAL_SIDE_8X21.5" urn="urn:adsk.eagle:package:7189333/3" type="model" library_version="29" library_locally_modified="yes">
@@ -671,36 +698,9 @@ No TH components allowed here</text>
 <packageinstance name="RADIAL_SIDE_8X21.5"/>
 </packageinstances>
 </package3d>
-</packages3d>
-</library>
-<library name="pinhead" urn="urn:adsk.eagle:library:2540341">
-<packages>
-<package name="1X02-PTH-2.54" urn="urn:adsk.eagle:footprint:2540357/1" library_version="30">
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="0.635" x2="-2.54" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="-1.905" y1="1.27" x2="-2.54" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="-0.635" x2="-1.905" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.2032" layer="21"/>
-<pad name="1" x="-1.27" y="0" drill="1" diameter="1.7" rot="R90"/>
-<pad name="2" x="1.27" y="0" drill="1" diameter="1.7" rot="R90"/>
-<text x="0" y="0" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="37"/>
-<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="37"/>
-</package>
-</packages>
-<packages3d>
-<package3d name="1X02-PTH-2.54" urn="urn:adsk.eagle:package:2540385/2" type="model" library_version="30">
+<package3d name="R0402" urn="urn:adsk.eagle:package:2539456/2" type="model" library_version="46" library_locally_modified="yes">
 <packageinstances>
-<packageinstance name="1X02-PTH-2.54"/>
+<packageinstance name="R0402"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -9756,47 +9756,47 @@ No TH components allowed here</text>
 </pass>
 </autorouter>
 <elements>
-<element name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="-5" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="-7" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="-9" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="13" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="11" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="9" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="7" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="5" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="3" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="1" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-1" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-3" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-5" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-7" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-9" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-11" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-13" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-9" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-7" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-5" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="3" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="5" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="7" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="9" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-13" smashed="yes" rot="MR0"/>
-<element name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-11" smashed="yes" rot="MR0"/>
-<element name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-9" smashed="yes" rot="MR0"/>
-<element name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-7" smashed="yes" rot="MR0"/>
-<element name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-5" smashed="yes" rot="MR0"/>
-<element name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-3" smashed="yes" rot="MR0"/>
-<element name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-1" smashed="yes" rot="MR0"/>
-<element name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="1" smashed="yes" rot="MR0"/>
-<element name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="3" smashed="yes" rot="MR0"/>
-<element name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="5" smashed="yes" rot="MR0"/>
-<element name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="7" smashed="yes" rot="MR0"/>
-<element name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="9" smashed="yes" rot="MR0"/>
-<element name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="11" smashed="yes" rot="MR0"/>
-<element name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="9" y="14.95" smashed="yes" rot="MR0"/>
-<element name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="7" y="14.95" smashed="yes" rot="MR0"/>
-<element name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="5" y="14.95" smashed="yes" rot="MR0"/>
-<element name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="3" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-5" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-7" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-9" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="13" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="11" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="9" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="7" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="5" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="3" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="1" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-1" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-3" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-5" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-7" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-9" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-11" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-13" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-9" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-7" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-5" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="3" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="5" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="7" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="9" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-13" smashed="yes" rot="MR0"/>
+<element name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-11" smashed="yes" rot="MR0"/>
+<element name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-9" smashed="yes" rot="MR0"/>
+<element name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-7" smashed="yes" rot="MR0"/>
+<element name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-5" smashed="yes" rot="MR0"/>
+<element name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-3" smashed="yes" rot="MR0"/>
+<element name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-1" smashed="yes" rot="MR0"/>
+<element name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="1" smashed="yes" rot="MR0"/>
+<element name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="3" smashed="yes" rot="MR0"/>
+<element name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="5" smashed="yes" rot="MR0"/>
+<element name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="7" smashed="yes" rot="MR0"/>
+<element name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="9" smashed="yes" rot="MR0"/>
+<element name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="11" smashed="yes" rot="MR0"/>
+<element name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="9" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="7" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="5" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="3" y="14.95" smashed="yes" rot="MR0"/>
 <element name="C10" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" package="C0402" package3d_urn="urn:adsk.eagle:package:2539379/2" value="0.1µF" x="-9.95" y="-5.05" smashed="yes" rot="R90">
 <attribute name="DIGIKEY#" value="490-3261-1-ND" x="109.05" y="-49.05" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="MANF" value="Murata Electronics North America" x="109.05" y="-49.05" size="1.778" layer="27" rot="R90" display="off"/>
@@ -9924,13 +9924,13 @@ No TH components allowed here</text>
 <attribute name="TOLERANCE" value="1%" x="39.55" y="195.85" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="VALUE" x="-10.45" y="-13.05" size="0.5" layer="27" font="vector" ratio="15" rot="R180" align="center"/>
 </element>
-<element name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5" x="-4" y="17.15" smashed="yes">
+<element name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="-4" y="17.15" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="-11" y="24.15" size="1.778" layer="27" display="off"/>
 </element>
-<element name="R4" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="5 mOhms" x="-4.5" y="1.375" locked="yes" smashed="yes">
-<attribute name="DIGIKEY#" value="CSNL2512FT5L00CT-ND" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
-<attribute name="MANF" value="Stackpole Electronics Inc." x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
-<attribute name="MANF#" value="CSNL2512FT5L00" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
+<element name="R4" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="10 mOhms" x="-4.5" y="1.375" locked="yes" smashed="yes">
+<attribute name="DIGIKEY#" value="CSNL2512FT10L0CT-ND" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
+<attribute name="MANF" value="Stackpole Electronics Inc" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
+<attribute name="MANF#" value="CSNL2512FT10L0" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
 <attribute name="NAME" x="-4.5" y="1.375" size="1.5" layer="25" font="vector" ratio="15" align="center"/>
 <attribute name="POWER" value="2W" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
 <attribute name="TC" value="±50ppm/°C" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
@@ -9972,13 +9972,13 @@ No TH components allowed here</text>
 <attribute name="TOLERANCE" value="5%" x="-7.05" y="-11.8" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="VALUE" x="-7.95" y="5.2" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5" x="0" y="17.15" smashed="yes" rot="R270">
+<element name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="0" y="17.15" smashed="yes" rot="R270">
 <attribute name="BOM" value="EXCLUDE" x="-18" y="27.15" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="R10" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="5 mOhms" x="4.5" y="1.375" locked="yes" smashed="yes">
-<attribute name="DIGIKEY#" value="CSNL2512FT5L00CT-ND" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
-<attribute name="MANF" value="Stackpole Electronics Inc." x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
-<attribute name="MANF#" value="CSNL2512FT5L00" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
+<element name="R10" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="10 mOhms" x="4.5" y="1.375" locked="yes" smashed="yes">
+<attribute name="DIGIKEY#" value="CSNL2512FT10L0CT-ND" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
+<attribute name="MANF" value="Stackpole Electronics Inc" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
+<attribute name="MANF#" value="CSNL2512FT10L0" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
 <attribute name="NAME" x="4.5" y="1.375" size="1.5" layer="25" font="vector" ratio="15" align="center"/>
 <attribute name="POWER" value="2W" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
 <attribute name="TC" value="±50ppm/°C" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
@@ -10002,7 +10002,7 @@ No TH components allowed here</text>
 <attribute name="TOLERANCE" value="5%" x="12.5" y="5.2" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="VALUE" x="1.6" y="5.2" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5" x="4" y="17.15" smashed="yes">
+<element name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="4" y="17.15" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="-9" y="-15.85" size="1.778" layer="27" display="off"/>
 </element>
 <element name="R11" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" package="R0402" package3d_urn="urn:adsk.eagle:package:2539512/2" value="4R3" x="8.65" y="5.2" smashed="yes" rot="R90">
@@ -10127,9 +10127,6 @@ No TH components allowed here</text>
 <attribute name="PACKAGE" value="RADIAL" x="8.15" y="-8.4" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="VOLTAGE" value="50V" x="8.15" y="-8.4" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="CON3" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" package="1X02-PTH-2.54" package3d_urn="urn:adsk.eagle:package:2540385/2" value="PINHEAD_1X02-2.54" x="10.425" y="-8.6" smashed="yes" rot="R270">
-<attribute name="NAME" x="10.425" y="-8.6" size="1" layer="25" font="vector" ratio="15" rot="R270" align="center"/>
-</element>
 <element name="IC3" library="serial_interfaces" library_urn="urn:adsk.eagle:library:4770999" package="SOIC8" package3d_urn="urn:adsk.eagle:package:4771007/3" value="TJA1051(X)/3-SO8" x="-5.4" y="-5.1" smashed="yes">
 <attribute name="DIGIKEY#" value="568-8684-2-ND" x="-5.4" y="-5.1" size="1.778" layer="27" display="off"/>
 <attribute name="MANF" value="NXP USA Inc" x="-5.4" y="-5.1" size="1.778" layer="27" display="off"/>
@@ -10175,15 +10172,17 @@ No TH components allowed here</text>
 <attribute name="MANF#" value="LTST-C19HE1WT" x="0.5" y="-13.3" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="NAME" x="0.5" y="-15.05" size="0.6" layer="26" font="vector" ratio="15" rot="MR0" align="center"/>
 </element>
-<element name="R14" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" package="R0402" package3d_urn="urn:adsk.eagle:package:2539512/2" value="1K" x="10.825" y="-5.325" smashed="yes">
-<attribute name="DIGIKEY#" value="311-1.00KLRCT-ND" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
-<attribute name="MANF" value="Yageo" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
-<attribute name="MANF#" value="RC0402FR-071KL" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
+<element name="R14" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="R0402" package3d_urn="urn:adsk.eagle:package:2539456/2" value="680R" x="10.825" y="-5.325" smashed="yes">
+<attribute name="AEC-Q" value="AEC-Q200" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
+<attribute name="DIGIKEY#" value="CRCW0402680RFKEDDatasheet " x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
+<attribute name="MANF" value="Vishay Dale" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
+<attribute name="MANF#" value="CRCW0402680RFKED" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
 <attribute name="NAME" x="10.825" y="-5.325" size="0.5" layer="25" font="vector" ratio="15" align="center"/>
 <attribute name="PACKAGE" value="0402" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
 <attribute name="TOLERANCE" value="1%" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
-<attribute name="VALUE" x="10.825" y="-4.425" size="0.5" layer="27" font="vector" ratio="15" align="center"/>
 </element>
+<element name="PAD47" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="1.5X1.5" package3d_urn="urn:adsk.eagle:package:15477730/1" value="PAD-S-1.5" x="10.425" y="-7.33" smashed="yes"/>
+<element name="PAD48" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="1.5X1.5" package3d_urn="urn:adsk.eagle:package:15477730/1" value="PAD-S-1.5" x="10.425" y="-9.87" smashed="yes"/>
 </elements>
 <signals>
 <signal name="PHASE_A_GND">
@@ -10512,13 +10511,10 @@ No TH components allowed here</text>
 <signal name="RGB_LED_R">
 <contactref element="PAD12" pad="P$1"/>
 <contactref element="R7" pad="2"/>
-<wire x1="12.45" y1="-3" x2="12.2" y2="-3" width="0.15" layer="1"/>
-<wire x1="12.2" y1="-3" x2="12.07" y2="-3" width="0.15" layer="1"/>
-<wire x1="12.07" y1="-3" x2="11.975" y2="-3" width="0.15" layer="1"/>
 <wire x1="9.3" y1="-5.325" x2="9.9" y2="-4.725" width="0.15" layer="1"/>
 <wire x1="9.9" y1="-4.725" x2="10.2485375" y2="-4.725" width="0.15" layer="1"/>
-<wire x1="11.9735375" y1="-3" x2="12.07" y2="-3" width="0.15" layer="1"/>
-<wire x1="10.2485375" y1="-4.725" x2="11.9735375" y2="-3" width="0.15" layer="1"/>
+<wire x1="11.9735375" y1="-3" x2="10.2485375" y2="-4.725" width="0.15" layer="1"/>
+<wire x1="12.45" y1="-3" x2="11.9735375" y2="-3" width="0.15" layer="1"/>
 </signal>
 <signal name="RGB_LED_G">
 <contactref element="PAD11" pad="P$1"/>
@@ -10539,7 +10535,6 @@ No TH components allowed here</text>
 <wire x1="12.45" y1="1" x2="12.45" y2="0.975" width="0.15" layer="1"/>
 <wire x1="12.45" y1="0.975" x2="11.775" y2="0.3" width="0.15" layer="1"/>
 <wire x1="11.775" y1="-1.175" x2="11.225" y2="-1.725" width="0.15" layer="1"/>
-<wire x1="7.45" y1="-6.475" x2="7.4" y2="-6.475" width="0.15" layer="1"/>
 <wire x1="11.225" y1="-1.725" x2="11.225" y2="-2.9" width="0.15" layer="1"/>
 <wire x1="11.225" y1="-2.9" x2="10" y2="-4.125" width="0.15" layer="1"/>
 <wire x1="7.4" y1="-4.7" x2="7.4" y2="-6.475" width="0.15" layer="1"/>
@@ -10548,11 +10543,10 @@ No TH components allowed here</text>
 </signal>
 <signal name="GPIO1">
 <contactref element="PAD14" pad="P$1"/>
-<contactref element="CON3" pad="2"/>
-<wire x1="10.425" y1="-9.87" x2="11.6" y2="-8.695" width="0.15" layer="1"/>
-<wire x1="11.6" y1="-8.695" x2="11.6" y2="-8.6" width="0.15" layer="1"/>
-<wire x1="12.45" y1="-7" x2="11.6" y2="-7.85" width="0.15" layer="1"/>
-<wire x1="11.6" y1="-7.85" x2="11.6" y2="-8.6" width="0.15" layer="1"/>
+<wire x1="12.45" y1="-7" x2="11.7" y2="-7.75" width="0.15" layer="1"/>
+<wire x1="11.7" y1="-7.75" x2="11.7" y2="-8.595" width="0.15" layer="1"/>
+<contactref element="PAD48" pad="P$1"/>
+<wire x1="11.7" y1="-8.595" x2="10.425" y2="-9.87" width="0.15" layer="1"/>
 </signal>
 <signal name="USART_TX">
 <contactref element="PAD19" pad="P$1"/>
@@ -10903,7 +10897,6 @@ No TH components allowed here</text>
 <wire x1="-8" y1="-4.465" x2="-9.865" y2="-4.465" width="0.4" layer="1"/>
 <wire x1="-9.865" y1="-4.465" x2="-9.95" y2="-4.55" width="0.4" layer="1"/>
 <contactref element="C11" pad="2"/>
-<contactref element="CON3" pad="1"/>
 <polygon width="0.15" layer="15" rank="4">
 <vertex x="-12.45" y="1.95"/>
 <vertex x="12.45" y="1.95"/>
@@ -10936,8 +10929,17 @@ No TH components allowed here</text>
 <wire x1="-10.975" y1="-9.1" x2="-10.625" y2="-8.75" width="0.15" layer="1"/>
 <wire x1="-10.625" y1="-8.75" x2="-10.625" y2="-8.25" width="0.15" layer="1"/>
 <contactref element="R14" pad="1"/>
-<wire x1="10.325" y1="-5.325" x2="10.325" y2="-7.23" width="0.3" layer="1"/>
-<wire x1="10.325" y1="-7.23" x2="10.425" y2="-7.33" width="0.3" layer="1"/>
+<contactref element="PAD47" pad="P$1"/>
+<via x="10.4" y="-6.1" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="11" y="-6.1" extent="1-16" drill="0.3" diameter="0.6"/>
+<polygon width="0.2" layer="1" thermals="no">
+<vertex x="11.3" y="-5.8"/>
+<vertex x="10.6" y="-5.8"/>
+<vertex x="10.6" y="-5.1"/>
+<vertex x="9.7" y="-5.1"/>
+<vertex x="9.7" y="-8"/>
+<vertex x="11.3" y="-8"/>
+</polygon>
 </signal>
 <signal name="VDC" class="1">
 <contactref element="C9" pad="2"/>
@@ -11497,12 +11499,9 @@ No TH components allowed here</text>
 <approved hash="21,19,74ae76ac76ac74ae"/>
 <approved hash="19,1,524d51da464445d3"/>
 <approved hash="19,16,1c1c1d0b19071810"/>
-<approved hash="19,16,fb25c3d101c50f21"/>
 <approved hash="3,16,5601e6f9e6b15649"/>
 <approved hash="3,1,5c43aa1dfc300a6e"/>
 <approved hash="6,1,39d605e161419c27"/>
-<approved hash="19,16,d9b1cf90359023b1"/>
-<approved hash="19,16,1f7aba674063e57e"/>
 <approved hash="23,1,a713f163f15fa72f"/>
 <approved hash="23,2,668c52705270668c"/>
 <approved hash="4,1,cfe86d94ed9a4fe6"/>
@@ -11510,19 +11509,16 @@ No TH components allowed here</text>
 <approved hash="4,1,37d4d5a855afb7d3"/>
 <approved hash="4,1,6c313c7e35b8148d"/>
 <approved hash="4,1,3591b4b234b3b590"/>
-<approved hash="4,1,303b908e43a97419"/>
 <approved hash="4,1,62bce1df61dee2bd"/>
 <approved hash="4,1,a6e72cc4acc526e6"/>
 <approved hash="19,16,161c16e102e50005"/>
 <approved hash="19,16,ae8550ee2094f8f1"/>
+<approved hash="19,16,3387491bc553c055"/>
+<approved hash="19,16,d6607b2574023d92"/>
 </errors>
 </board>
 </drawing>
 <compatibility>
-<note version="6.3" minversion="6.2.2" severity="warning">
-Since Version 6.2.2 text objects can contain more than one line,
-which will not be processed correctly with this version.
-</note>
 <note version="8.2" severity="warning">
 Since Version 8.2, EAGLE supports online libraries. The ids
 of those online libraries will not be understood (or retained)

--- a/bloxa.brd
+++ b/bloxa.brd
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="1" unitdist="mm" unit="mm" style="lines" multiple="2" display="no" altdistance="0.25" altunitdist="mm" altunit="mm"/>
+<grid distance="0.1" unitdist="mm" unit="mm" style="lines" multiple="2" display="no" altdistance="0.25" altunitdist="mm" altunit="mm"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="pwr" color="1" fill="3" visible="no" active="yes"/>
@@ -67,6 +67,7 @@
 <layer number="57" name="tCAD" color="12" fill="1" visible="no" active="no"/>
 <layer number="58" name="bCAD" color="9" fill="1" visible="no" active="no"/>
 <layer number="59" name="Invisible" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
 <layer number="61" name="stand" color="7" fill="1" visible="no" active="no"/>
 <layer number="88" name="SimResults" color="9" fill="1" visible="no" active="no"/>
 <layer number="89" name="SimProbes" color="9" fill="1" visible="no" active="no"/>
@@ -114,15 +115,26 @@
 <layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
 <layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
 <layer number="133" name="bottom_silk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="134" name="silk_top" color="7" fill="1" visible="no" active="yes"/>
+<layer number="135" name="silk_bottom" color="7" fill="1" visible="no" active="yes"/>
+<layer number="136" name="silktop" color="7" fill="1" visible="no" active="yes"/>
+<layer number="137" name="silkbottom" color="7" fill="1" visible="no" active="yes"/>
+<layer number="138" name="EEE" color="7" fill="1" visible="no" active="yes"/>
+<layer number="139" name="_tKeepout" color="7" fill="1" visible="no" active="yes"/>
+<layer number="141" name="ASSEMBLY_TOP" color="7" fill="1" visible="no" active="yes"/>
+<layer number="143" name="PLACE_BOUND_TOP" color="7" fill="1" visible="no" active="yes"/>
 <layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
 <layer number="145" name="DrillLegend_01-16" color="2" fill="9" visible="no" active="yes"/>
 <layer number="146" name="DrillLegend_01-20" color="3" fill="9" visible="no" active="yes"/>
+<layer number="147" name="PIN_NUMBER" color="7" fill="1" visible="no" active="yes"/>
 <layer number="150" name="Notes" color="7" fill="1" visible="no" active="yes"/>
 <layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
 <layer number="152" name="_bDocu" color="7" fill="1" visible="no" active="yes"/>
 <layer number="153" name="FabDoc1" color="6" fill="1" visible="no" active="no"/>
 <layer number="154" name="FabDoc2" color="2" fill="1" visible="no" active="no"/>
 <layer number="155" name="FabDoc3" color="7" fill="15" visible="no" active="no"/>
+<layer number="166" name="AntennaArea" color="7" fill="1" visible="no" active="yes"/>
+<layer number="168" name="4mmHeightArea" color="7" fill="1" visible="no" active="yes"/>
 <layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
 <layer number="200" name="200bmp" color="1" fill="10" visible="no" active="yes"/>
 <layer number="201" name="201bmp" color="2" fill="10" visible="no" active="yes"/>
@@ -176,7 +188,7 @@
 <wire x1="-10.95" y1="18.65" x2="-12.45" y2="17.15" width="0.01" layer="20" curve="90"/>
 <wire x1="-12.45" y1="17.15" x2="-12.45" y2="-13.45" width="0.01" layer="20" locked="yes"/>
 <wire x1="-12.45" y1="-13.45" x2="-10.95" y2="-14.95" width="0.01" layer="20" curve="90" locked="yes"/>
-<text x="-5.25" y="-2.15" size="0.7" layer="1" font="vector" ratio="17" align="bottom-right">BLOXA 0.2</text>
+<text x="-5.45" y="-2.15" size="0.8" layer="1" font="vector" ratio="20" align="bottom-right">BLOXA 0.2</text>
 <text x="-8.35" y="16.8" size="0.6" layer="21" font="vector" ratio="15" align="center">C1</text>
 <text x="0" y="16.025" size="0.6" layer="21" font="vector" ratio="15" align="center">C2</text>
 <text x="8.4" y="16.8" size="0.6" layer="21" font="vector" ratio="15" align="center">C3</text>
@@ -399,43 +411,11 @@
 <rectangle x1="-1.65" y1="-0.25" x2="-0.75" y2="0.25" layer="51"/>
 <circle x="-1" y="1.6" radius="0.111803125" width="0.1" layer="21"/>
 </package>
-<package name="LITE_ON_RGB_LED" urn="urn:adsk.eagle:footprint:1040103/1" library_version="1">
-<smd name="R" x="-0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="G" x="0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="+" x="-0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="B" x="0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
-<text x="0" y="1.75" size="0.6" layer="25" font="vector" ratio="15" rot="R180" align="center">&gt;NAME</text>
-<wire x1="-0.95" y1="1.35" x2="0.95" y2="1.35" width="0.1524" layer="21"/>
-<wire x1="0.95" y1="1.35" x2="0.95" y2="-1.35" width="0.1524" layer="21"/>
-<wire x1="0.95" y1="-1.35" x2="-0.95" y2="-1.35" width="0.1524" layer="21"/>
-<wire x1="-0.95" y1="-1.35" x2="-0.95" y2="1.35" width="0.1524" layer="21"/>
-<circle x="-1.25" y="1.25" radius="0.1" width="0.1524" layer="21"/>
-</package>
-<package name="0402_LED" urn="urn:adsk.eagle:footprint:1040136/1" library_version="1">
-<smd name="C" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<smd name="A" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<wire x1="-0.95" y1="0.5" x2="0.95" y2="0.5" width="0.15" layer="21"/>
-<wire x1="0.95" y1="0.5" x2="0.95" y2="-0.5" width="0.15" layer="21"/>
-<wire x1="0.95" y1="-0.5" x2="-0.95" y2="-0.5" width="0.15" layer="21"/>
-<wire x1="-0.95" y1="-0.5" x2="-0.95" y2="0.5" width="0.15" layer="21"/>
-<wire x1="-0.4" y1="0.5" x2="-0.4" y2="-0.5" width="0.15" layer="51"/>
-</package>
 </packages>
 <packages3d>
 <package3d name="SOT26" urn="urn:adsk.eagle:package:1040217/3" type="model" library_version="19">
 <packageinstances>
 <packageinstance name="SOT26"/>
-</packageinstances>
-</package3d>
-<package3d name="LITE_ON_RGB_LED" urn="urn:adsk.eagle:package:1040199/2" type="model" library_version="18">
-<packageinstances>
-<packageinstance name="LITE_ON_RGB_LED"/>
-</packageinstances>
-</package3d>
-<package3d name="0402_LED" urn="urn:adsk.eagle:package:1040216/2" type="model" library_version="15" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="0402_LED"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -618,6 +598,18 @@
 <circle x="0" y="0" radius="1.5" width="0.127" layer="41"/>
 <smd name="P$1" x="0" y="0" dx="1.016" dy="1.016" layer="1" roundness="100" cream="no"/>
 </package>
+<package name="0606" urn="urn:adsk.eagle:footprint:20072924/1" library_version="83" library_locally_modified="yes">
+<circle x="-1.25" y="1.25" radius="0.1" width="0.1524" layer="21"/>
+<wire x1="-0.95" y1="1.35" x2="0.95" y2="1.35" width="0.1524" layer="21"/>
+<wire x1="0.95" y1="1.35" x2="0.95" y2="-1.35" width="0.1524" layer="21"/>
+<wire x1="0.95" y1="-1.35" x2="-0.95" y2="-1.35" width="0.1524" layer="21"/>
+<wire x1="-0.95" y1="-1.35" x2="-0.95" y2="1.35" width="0.1524" layer="21"/>
+<smd name="+" x="-0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="B" x="0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="G" x="0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="R" x="-0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
+<text x="0" y="1.75" size="0.6" layer="25" font="vector" ratio="15" rot="R180" align="center">&gt;NAME</text>
+</package>
 </packages>
 <packages3d>
 <package3d name="SENSE-0.6" urn="urn:adsk.eagle:package:7365871/1" type="box" library_version="8">
@@ -633,6 +625,11 @@
 <package3d name="CONNECTION" urn="urn:adsk.eagle:package:7439847/1" type="box" library_version="9">
 <packageinstances>
 <packageinstance name="CONNECTION"/>
+</packageinstances>
+</package3d>
+<package3d name="0606" urn="urn:adsk.eagle:package:20072926/2" type="model" library_version="83" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="0606"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -691,6 +688,22 @@
 <wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
 <wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
 </package>
+<package name="LED0402" urn="urn:adsk.eagle:footprint:2539447/1" library_version="54">
+<smd name="A" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="C" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.4064" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="0.45" x2="0.1" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.1" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="-0.45" x2="0.1" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.1" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.1" y1="0.45" x2="0.1" y2="-0.45" width="0.1" layer="21"/>
+</package>
 </packages>
 <packages3d>
 <package3d name="RADIAL_SIDE_8X21.5" urn="urn:adsk.eagle:package:7189333/3" type="model" library_version="29" library_locally_modified="yes">
@@ -701,6 +714,11 @@
 <package3d name="R0402" urn="urn:adsk.eagle:package:2539456/2" type="model" library_version="46" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="R0402"/>
+</packageinstances>
+</package3d>
+<package3d name="LED0402" urn="urn:adsk.eagle:package:2539470/2" type="model" library_version="54">
+<packageinstances>
+<packageinstance name="LED0402"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -9547,7 +9565,7 @@
 <attributes>
 </attributes>
 <variantdefs>
-<variantdef name="Basic" current="yes"/>
+<variantdef name="Basic"/>
 <variantdef name="nocaps"/>
 </variantdefs>
 <classes>
@@ -9756,47 +9774,47 @@
 </pass>
 </autorouter>
 <elements>
-<element name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-5" y="14.95" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-7" y="14.95" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-9" y="14.95" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="13" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="11" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="9" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="7" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="5" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="3" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="1" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-1" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-3" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-5" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-7" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-9" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-11" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-13" locked="yes" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-9" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-7" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-5" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="3" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="5" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="7" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="9" y="-14.95" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-13" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-11" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-9" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-7" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-5" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-3" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-1" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="1" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="3" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="5" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="7" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="9" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="11" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="9" y="14.95" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="7" y="14.95" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="5" y="14.95" populate="no" smashed="yes" rot="MR0"/>
-<element name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="3" y="14.95" populate="no" smashed="yes" rot="MR0"/>
+<element name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-5" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-7" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-9" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="13" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="11" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="9" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="7" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="5" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="3" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="1" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-1" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-3" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-5" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-7" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-9" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-11" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-13" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-9" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-7" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-5" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="3" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="5" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="7" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="9" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-13" smashed="yes" rot="MR0"/>
+<element name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-11" smashed="yes" rot="MR0"/>
+<element name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-9" smashed="yes" rot="MR0"/>
+<element name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-7" smashed="yes" rot="MR0"/>
+<element name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-5" smashed="yes" rot="MR0"/>
+<element name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-3" smashed="yes" rot="MR0"/>
+<element name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-1" smashed="yes" rot="MR0"/>
+<element name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="1" smashed="yes" rot="MR0"/>
+<element name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="3" smashed="yes" rot="MR0"/>
+<element name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="5" smashed="yes" rot="MR0"/>
+<element name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="7" smashed="yes" rot="MR0"/>
+<element name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="9" smashed="yes" rot="MR0"/>
+<element name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="11" smashed="yes" rot="MR0"/>
+<element name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="9" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="7" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="5" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="3" y="14.95" smashed="yes" rot="MR0"/>
 <element name="C10" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" package="C0402" package3d_urn="urn:adsk.eagle:package:2539379/2" value="0.1µF" x="-9.95" y="-5.05" smashed="yes" rot="R90">
 <attribute name="DIGIKEY#" value="490-3261-1-ND" x="109.05" y="-49.05" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="MANF" value="Murata Electronics North America" x="109.05" y="-49.05" size="1.778" layer="27" rot="R90" display="off"/>
@@ -9875,18 +9893,18 @@
 <attribute name="VALUE" x="3.55" y="-6.55" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 <attribute name="VOLTAGE" value="25V" x="187.45" y="-17.55" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="LED4" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="LITE_ON_RGB_LED" package3d_urn="urn:adsk.eagle:package:1040199/2" value="LTST-C19HE1WT" x="10.45" y="-13" smashed="yes" rot="R270">
+<element name="LED4" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="0606" package3d_urn="urn:adsk.eagle:package:20072926/2" value="LTST-C19HE1WT" x="10.45" y="-13" smashed="yes" rot="R270">
 <attribute name="DIGIKEY#" value="160-2162-1-ND" x="-184.55" y="-9" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="MANF" value="Lite-On Inc" x="-184.55" y="-9" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="MANF#" value="LTST-C19HE1WT" x="-184.55" y="-9" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="NAME" x="10.575" y="-13" size="0.6" layer="25" font="vector" ratio="15" rot="R180" align="center"/>
 </element>
-<element name="LED2" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="0402_LED" package3d_urn="urn:adsk.eagle:package:1040216/2" value="GREEN" x="-10.45" y="-13.75" smashed="yes">
-<attribute name="COLOR" value="GREEN" x="-27.45" y="-203.75" size="1.778" layer="27" display="off"/>
-<attribute name="DIGIKEY#" value="511-1652-1-ND" x="-27.45" y="-203.75" size="1.778" layer="27" display="off"/>
-<attribute name="MANF" value="Rohm Semiconductor" x="-27.45" y="-203.75" size="1.778" layer="27" display="off"/>
-<attribute name="MANF#" value="SML-P11MTT86" x="-27.45" y="-203.75" size="1.778" layer="27" display="off"/>
-<attribute name="NAME" x="-10.45" y="-14.65" size="0.5" layer="25" font="vector" ratio="15" align="center"/>
+<element name="LED2" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="LED0402" package3d_urn="urn:adsk.eagle:package:2539470/2" value="GREEN" x="-10.45" y="-13.75" smashed="yes" rot="R180">
+<attribute name="COLOR" value="GREEN" x="6.55" y="176.25" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="DIGIKEY#" value="1830-IN-S42BT5GCT-ND" x="6.55" y="176.25" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="MANF" value="Inolux" x="6.55" y="176.25" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="MANF#" value="IN-S42BT5G" x="6.55" y="176.25" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="-10.45" y="-13.75" size="0.4064" layer="25" font="vector" ratio="15" rot="R180" align="center"/>
 </element>
 <element name="R5" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" package="R0402" package3d_urn="urn:adsk.eagle:package:2539512/2" value="1K" x="7.4" y="-6.975" smashed="yes" rot="R90">
 <attribute name="DIGIKEY#" value="311-1.00KLRCT-ND" x="206.4" y="-62.975" size="1.778" layer="27" rot="R90" display="off"/>
@@ -9924,7 +9942,7 @@
 <attribute name="TOLERANCE" value="1%" x="39.55" y="195.85" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="VALUE" x="-10.45" y="-13.05" size="0.5" layer="27" font="vector" ratio="15" rot="R180" align="center"/>
 </element>
-<element name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="-4" y="17.15" populate="no" smashed="yes">
+<element name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="-4" y="17.15" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="-11" y="24.15" size="1.778" layer="27" display="off"/>
 </element>
 <element name="R4" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="10 mOhms" x="-4.5" y="1.375" locked="yes" smashed="yes">
@@ -9972,7 +9990,7 @@
 <attribute name="TOLERANCE" value="5%" x="-7.05" y="-11.8" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="VALUE" x="-7.95" y="5.2" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="0" y="17.15" populate="no" smashed="yes" rot="R270">
+<element name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="0" y="17.15" smashed="yes" rot="R270">
 <attribute name="BOM" value="EXCLUDE" x="-18" y="27.15" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
 <element name="R10" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="10 mOhms" x="4.5" y="1.375" locked="yes" smashed="yes">
@@ -10002,7 +10020,7 @@
 <attribute name="TOLERANCE" value="5%" x="12.5" y="5.2" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="VALUE" x="1.6" y="5.2" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="4" y="17.15" populate="no" smashed="yes">
+<element name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="4" y="17.15" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="-9" y="-15.85" size="1.778" layer="27" display="off"/>
 </element>
 <element name="R11" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" package="R0402" package3d_urn="urn:adsk.eagle:package:2539512/2" value="4R3" x="8.65" y="5.2" smashed="yes" rot="R90">
@@ -10023,7 +10041,7 @@
 <attribute name="TOLERANCE" value="5%" x="31.3" y="-0.8" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="VALUE" x="10.4" y="5.2" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="S1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="SENSE-0.6" package3d_urn="urn:adsk.eagle:package:7365871/1" value="SENSE" x="9.8" y="3" populate="no" smashed="yes" rot="MR0">
+<element name="S1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="SENSE-0.6" package3d_urn="urn:adsk.eagle:package:7365871/1" value="SENSE" x="9.8" y="3" smashed="yes" rot="MR0">
 <attribute name="BOM" value="EXCLUDE" x="22.8" y="-20" size="1.778" layer="28" rot="MR0" display="off"/>
 </element>
 <element name="C7" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" package="C1210" package3d_urn="urn:adsk.eagle:package:2539380/2" value="10µF" x="-4.6" y="7" smashed="yes" rot="R90">
@@ -10091,16 +10109,16 @@
 <attribute name="NAME" x="9.2" y="10" size="1.5" layer="25" font="vector" ratio="15" rot="R90" align="center"/>
 <attribute name="PACKAGE" value="56LFPAK" x="95.2" y="9" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="PAD43" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="4X2" package3d_urn="urn:adsk.eagle:package:3188708/1" value="PAD-4X2" x="10.5" y="1.4" locked="yes" populate="no" smashed="yes" rot="R90">
+<element name="PAD43" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="4X2" package3d_urn="urn:adsk.eagle:package:3188708/1" value="PAD-4X2" x="10.5" y="1.4" locked="yes" smashed="yes" rot="R90">
 <attribute name="BOM" value="EXCLUDE" x="10.5" y="1.4" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="PAD42" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="4X2" package3d_urn="urn:adsk.eagle:package:3188708/1" value="PAD-4X2" x="-10.5" y="1.4" locked="yes" populate="no" smashed="yes" rot="R90">
+<element name="PAD42" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="4X2" package3d_urn="urn:adsk.eagle:package:3188708/1" value="PAD-4X2" x="-10.5" y="1.4" locked="yes" smashed="yes" rot="R90">
 <attribute name="BOM" value="EXCLUDE" x="-10.5" y="1.4" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="D1" library="TVS_diodes" library_urn="urn:adsk.eagle:library:3333632" package="SOD128" package3d_urn="urn:adsk.eagle:package:6533206/2" value="PTVS36VP1UP,115-36V-SOD128" x="6.95" y="-2.85" smashed="yes" rot="R180">
-<attribute name="DIGIKEY#" value="1727-4439-2-ND" x="60.45" y="-15.35" size="1.778" layer="27" rot="R180" display="off"/>
+<element name="D1" library="TVS_diodes" library_urn="urn:adsk.eagle:library:3333632" package="SOD128" package3d_urn="urn:adsk.eagle:package:6533206/2" value="PTVS33VP1UTP,115-36V-SOD128" x="6.95" y="-2.85" smashed="yes" rot="R180">
+<attribute name="DIGIKEY#" value="1727-1411-1-ND" x="60.45" y="-15.35" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="MANF" value="Nexperia USA Inc" x="60.45" y="-15.35" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="MANF#" value="PTVS36VP1UP,115" x="60.45" y="-15.35" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="MANF#" value="PTVS33VP1UTP,115" x="60.45" y="-15.35" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="NAME" x="6.95" y="-2.85" size="1" layer="25" font="vector" ratio="15" align="center"/>
 </element>
 <element name="C1" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="RADIAL_SIDE_8X21.5" package3d_urn="urn:adsk.eagle:package:7189333/3" value="180µF" x="-8.4" y="16.8" locked="yes" smashed="yes" rot="R180">
@@ -10147,26 +10165,26 @@
 <attribute name="VALUE" x="-10.475" y="-9.735" size="0.5" layer="27" font="vector" ratio="15" rot="R180" align="bottom-center"/>
 <attribute name="VOLTAGE" value="16V" x="-10.475" y="-9.1" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="J2" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="CONNECTION" package3d_urn="urn:adsk.eagle:package:7439847/1" value="CONNECTION" x="-6.775" y="-7.8" populate="no" smashed="yes" rot="MR180">
+<element name="J2" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="CONNECTION" package3d_urn="urn:adsk.eagle:package:7439847/1" value="CONNECTION" x="-6.775" y="-7.8" smashed="yes" rot="MR180">
 <attribute name="BOM" value="EXCLUDE" x="-6.775" y="-8.325" size="1.778" layer="28" rot="MR180" display="off"/>
 </element>
-<element name="FD2" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="FIDUCIA-MOUNT" value="FIDUCIALMOUNT" x="-3" y="-14.075" populate="no" smashed="yes">
+<element name="FD2" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="FIDUCIA-MOUNT" value="FIDUCIALMOUNT" x="-3" y="-14.075" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="-3" y="-14.075" size="1.778" layer="27" display="off"/>
 </element>
-<element name="FD1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="FIDUCIA-MOUNT" value="FIDUCIALMOUNT" x="11.4" y="17.6" populate="no" smashed="yes">
+<element name="FD1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="FIDUCIA-MOUNT" value="FIDUCIALMOUNT" x="11.4" y="17.6" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="11.4" y="17.6" size="1.778" layer="27" display="off"/>
 </element>
-<element name="J1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="CONNECTION" package3d_urn="urn:adsk.eagle:package:7439847/1" value="CONNECTION" x="10.5" y="-1.2" populate="no" smashed="yes" rot="MR90">
+<element name="J1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="CONNECTION" package3d_urn="urn:adsk.eagle:package:7439847/1" value="CONNECTION" x="10.5" y="-1.2" smashed="yes" rot="MR90">
 <attribute name="BOM" value="EXCLUDE" x="10.5" y="-1.2" size="1.778" layer="28" rot="MR90" display="off"/>
 </element>
-<element name="LED1" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="0402_LED" package3d_urn="urn:adsk.eagle:package:1040216/2" value="GREEN" x="-2.425" y="-14.05" populate="no" smashed="yes" rot="MR180">
-<attribute name="COLOR" value="GREEN" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
-<attribute name="DIGIKEY#" value="511-1652-1-ND" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
-<attribute name="MANF" value="Rohm Semiconductor" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
-<attribute name="MANF#" value="SML-P11MTT86" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
-<attribute name="NAME" x="-2.425" y="-14.05" size="0.5" layer="26" font="vector" ratio="15" rot="MR180" align="center"/>
+<element name="LED1" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="LED0402" package3d_urn="urn:adsk.eagle:package:2539470/2" value="GREEN" x="-2.425" y="-14.05" smashed="yes" rot="MR0">
+<attribute name="COLOR" value="" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR0" display="off"/>
+<attribute name="DIGIKEY#" value="" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR0" display="off"/>
+<attribute name="MANF" value="" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR0" display="off"/>
+<attribute name="MANF#" value="" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR0" display="off"/>
+<attribute name="NAME" x="-2.425" y="-14.05" size="0.5" layer="26" font="vector" ratio="15" rot="MR0" align="center"/>
 </element>
-<element name="LED3" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="LITE_ON_RGB_LED" package3d_urn="urn:adsk.eagle:package:1040199/2" value="LTST-C19HE1WT" x="0.5" y="-13.3" populate="no" smashed="yes" rot="MR180">
+<element name="LED3" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="0606" package3d_urn="urn:adsk.eagle:package:20072926/2" value="LTST-C19HE1WT" x="0.5" y="-13.3" smashed="yes" rot="MR180">
 <attribute name="DIGIKEY#" value="160-2162-1-ND" x="0.5" y="-13.3" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="MANF" value="Lite-On Inc" x="0.5" y="-13.3" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="MANF#" value="LTST-C19HE1WT" x="0.5" y="-13.3" size="1.778" layer="28" rot="MR180" display="off"/>
@@ -10498,9 +10516,9 @@
 <wire x1="-8" y1="-3.195" x2="-7.65" y2="-3.195" width="0.15" layer="1"/>
 <wire x1="0.575" y1="-1" x2="0.575" y2="-1.15" width="0.15" layer="1"/>
 <wire x1="0.575" y1="-1.15" x2="0.225" y2="-1.5" width="0.15" layer="1"/>
-<wire x1="0.225" y1="-1.5" x2="-3.45" y2="-1.5" width="0.15" layer="1"/>
-<wire x1="-3.45" y1="-1.5" x2="-5.15" y2="-3.2" width="0.15" layer="1"/>
-<wire x1="-5.15" y1="-3.2" x2="-7.65" y2="-3.2" width="0.15" layer="1"/>
+<wire x1="0.225" y1="-1.5" x2="-3.95" y2="-1.5" width="0.15" layer="1"/>
+<wire x1="-3.95" y1="-1.5" x2="-5.65" y2="-3.2" width="0.15" layer="1"/>
+<wire x1="-5.65" y1="-3.2" x2="-7.65" y2="-3.2" width="0.15" layer="1"/>
 <via x="0.575" y="-1" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="-7.65" y1="-3.195" x2="-7.65" y2="-3.2" width="0.15" layer="1"/>
 <wire x1="2.7" y1="2.95" x2="0.825" y2="1.075" width="0.15" layer="16"/>
@@ -10569,13 +10587,11 @@
 <wire x1="3.025" y1="13.375" x2="3.025" y2="2.85" width="0.15" layer="16"/>
 <wire x1="1.325" y1="-1.15" x2="1.325" y2="-1" width="0.15" layer="1"/>
 <wire x1="1.325" y1="-1.15" x2="0.625" y2="-1.85" width="0.15" layer="1"/>
-<wire x1="0.625" y1="-1.85" x2="-3.3" y2="-1.85" width="0.15" layer="1"/>
+<wire x1="0.625" y1="-1.85" x2="-3.75" y2="-1.85" width="0.15" layer="1"/>
 <wire x1="1.175" y1="-0.85" x2="1.325" y2="-1" width="0.15" layer="16"/>
 <wire x1="1.175" y1="1" x2="1.175" y2="-0.85" width="0.15" layer="16"/>
-<wire x1="-3.3" y1="-1.85" x2="-4.95" y2="-3.5" width="0.15" layer="1"/>
-<wire x1="-4.95" y1="-3.5" x2="-5.9" y2="-3.5" width="0.15" layer="1"/>
-<wire x1="-5.9" y1="-3.5" x2="-6.65" y2="-4.25" width="0.15" layer="1"/>
-<wire x1="-6.65" y1="-4.25" x2="-6.65" y2="-6.5" width="0.15" layer="1"/>
+<wire x1="-3.75" y1="-1.85" x2="-6.65" y2="-4.75" width="0.15" layer="1"/>
+<wire x1="-6.65" y1="-4.75" x2="-6.65" y2="-6.5" width="0.15" layer="1"/>
 </signal>
 <signal name="VDD_5V">
 <contactref element="PAD22" pad="P$1"/>
@@ -10923,8 +10939,6 @@
 <wire x1="-0.875" y1="-3.625" x2="-0.975" y2="-3.725" width="0.3" layer="1"/>
 <via x="-10.775" y="-10.85" extent="1-16" drill="0.3" diameter="0.6"/>
 <via x="-7.25" y="-11.575" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-5.8" y="-4.3" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-6.05" y="-6.1" extent="1-16" drill="0.3" diameter="0.6"/>
 <via x="-10.625" y="-8.25" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="-10.975" y1="-9.1" x2="-10.625" y2="-8.75" width="0.15" layer="1"/>
 <wire x1="-10.625" y1="-8.75" x2="-10.625" y2="-8.25" width="0.15" layer="1"/>
@@ -10941,20 +10955,10 @@
 <vertex x="11.3" y="-8"/>
 </polygon>
 <contactref element="IC3" pad="8"/>
-<wire x1="-10.975" y1="-9.1" x2="-10.775" y2="-10.85" width="0" layer="19" extent="1-1"/>
-<wire x1="-7.125" y1="-7.8" x2="-10.625" y2="-8.25" width="0" layer="19" extent="16-16"/>
-<wire x1="-6.05" y1="-6.1" x2="-7.125" y2="-7.8" width="0" layer="19" extent="16-16"/>
-<wire x1="-5.8" y1="-4.3" x2="-6.05" y2="-6.1" width="0" layer="19" extent="1-1"/>
-<wire x1="-8" y1="-4.465" x2="-5.8" y2="-4.3" width="0" layer="19" extent="1-1"/>
-<wire x1="-2.8" y1="-3.195" x2="-5.8" y2="-4.3" width="0" layer="19" extent="1-1"/>
-<wire x1="-0.975" y1="-3.725" x2="-2.8" y2="-3.195" width="0" layer="19" extent="1-1"/>
-<wire x1="-1.2" y1="-4.85" x2="-0.975" y2="-3.725" width="0" layer="19" extent="1-1"/>
-<wire x1="-7.25" y1="-11.575" x2="-10.775" y2="-10.85" width="0" layer="19" extent="1-1"/>
-<wire x1="10.325" y1="-5.325" x2="0.175" y2="-3.625" width="0" layer="19" extent="1-1"/>
-<wire x1="10.4" y1="-6.1" x2="10.325" y2="-5.325" width="0" layer="19" extent="1-1"/>
-<wire x1="11" y1="-6.1" x2="10.4" y2="-6.1" width="0" layer="19" extent="1-1"/>
-<wire x1="10.425" y1="-7.33" x2="10.4" y2="-6.1" width="0" layer="19" extent="1-1"/>
-<wire x1="10.5" y1="-1.55" x2="10.325" y2="-5.325" width="0" layer="19" extent="1-16"/>
+<via x="-4.6" y="-3.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<wire x1="-2.8" y1="-3.195" x2="-2.9" y2="-3.295" width="0.3" layer="1"/>
+<wire x1="-2.9" y1="-3.295" x2="-4.095" y2="-3.295" width="0.3" layer="1"/>
+<wire x1="-4.095" y1="-3.295" x2="-4.6" y2="-3.8" width="0.3" layer="1"/>
 </signal>
 <signal name="VDC" class="1">
 <contactref element="C9" pad="2"/>
@@ -11269,8 +11273,8 @@
 <vertex x="-12.45" y="2.1"/>
 <vertex x="-3.1" y="2.1"/>
 <vertex x="-3.1" y="-1"/>
-<vertex x="-0.175" y="-1"/>
-<vertex x="-0.175" y="-0.2"/>
+<vertex x="-0.275" y="-1"/>
+<vertex x="-0.275" y="-0.2"/>
 <vertex x="6" y="-0.2"/>
 <vertex x="6" y="-1"/>
 <vertex x="12.45" y="-1"/>
@@ -11324,12 +11328,12 @@
 <via x="-1.575" y="3.55" extent="1-16" drill="0.3" diameter="0.6"/>
 <via x="-1" y="3.55" extent="1-16" drill="0.3" diameter="0.6"/>
 <via x="-0.4" y="3.55" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-2.775" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-2.175" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-1.575" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-0.975" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-2.875" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-2.275" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-1.675" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-1.075" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
 <via x="-3.375" y="3.55" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-0.375" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-0.475" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
 <polygon width="0.2" layer="1" thermals="no" rank="2">
 <vertex x="11.425" y="-0.5"/>
 <vertex x="11.425" y="4.6"/>
@@ -11363,14 +11367,13 @@
 <vertex x="11.425" y="-0.025"/>
 </polygon>
 <contactref element="C5" pad="2"/>
-<wire x1="-9.8" y1="18" x2="-9.8" y2="17.425" width="0.2" layer="1"/>
 <wire x1="-9.675" y1="15.075" x2="-9.175" y2="15.075" width="0.2" layer="1"/>
 <wire x1="-9.175" y1="15.075" x2="-9.025" y2="15.225" width="0.2" layer="1"/>
 <wire x1="-9.025" y1="15.225" x2="-9.025" y2="16.15" width="0.2" layer="1"/>
 <wire x1="-9.675" y1="16.8" x2="-10.15" y2="16.8" width="0.2" layer="1"/>
 <wire x1="-9.025" y1="16.15" x2="-9.675" y2="16.8" width="0.2" layer="1"/>
 <wire x1="-10.15" y1="16.8" x2="-9.8" y2="16.8" width="0.2" layer="1"/>
-<wire x1="-9.8" y1="16.8" x2="-9.8" y2="17.425" width="0.2" layer="1"/>
+<wire x1="-9.8" y1="16.8" x2="-9.8" y2="18" width="0.2" layer="1"/>
 <contactref element="J1" pad="P$2"/>
 <polygon width="0.15" layer="16" rank="3">
 <vertex x="-12.45" y="18.65"/>
@@ -11511,9 +11514,7 @@
 <approved hash="19,1,524d51da464445d3"/>
 <approved hash="19,16,1c1c1d0b19071810"/>
 <approved hash="3,16,5601e6f9e6b15649"/>
-<approved hash="3,1,5c43aa1dfc300a6e"/>
 <approved hash="6,1,39d605e161419c27"/>
-<approved hash="23,1,a713f163f15fa72f"/>
 <approved hash="23,2,668c52705270668c"/>
 <approved hash="4,1,cfe86d94ed9a4fe6"/>
 <approved hash="4,1,0be2a99e29a58bd9"/>
@@ -11526,6 +11527,176 @@
 <approved hash="19,16,ae8550ee2094f8f1"/>
 <approved hash="19,16,3387491bc553c055"/>
 <approved hash="19,16,d6607b2574023d92"/>
+<approved hash="4,1,2219a83a283ba218"/>
+<approved hash="4,1,7fba2d10ca37a2e0"/>
+<approved hash="4,1,74f8fa1b7a1af4f9"/>
+<approved hash="4,1,73d7aba0252937a1"/>
+<approved hash="4,1,819b0f788f79019a"/>
+<approved hash="4,1,9a5f193c993d1a5e"/>
+<approved hash="4,1,ac23130093012c22"/>
+<approved hash="4,1,b8ab2688a68938aa"/>
+<approved hash="4,1,b16f304cb04d316e"/>
+<approved hash="4,1,4bcccaef4aeecbcd"/>
+<approved hash="4,1,5d08c32b432add09"/>
+<approved hash="4,1,6880d7a357a2e881"/>
+<approved hash="4,1,2ec12e826cf66cb5"/>
+<approved hash="4,1,c8e2469ee8405d55"/>
+<approved hash="4,1,7f8b9c4776f49120"/>
+<approved hash="4,1,2574b3ebc2015b66"/>
+<approved hash="4,1,e60d4f58cf64a459"/>
+<approved hash="4,1,58c9f7984bbd259d"/>
+<approved hash="4,1,c3414d58c97c8115"/>
+<approved hash="4,1,378237b63fd63fe2"/>
+<approved hash="4,1,cb29b35f5729e5a0"/>
+<approved hash="4,1,f514ae988257e3d9"/>
+<approved hash="4,1,1ea19dc21dc39ea0"/>
+<approved hash="4,1,3c55a2762277bc54"/>
+<approved hash="4,1,8aca70a9f0a80acb"/>
+<approved hash="4,1,f0067ee5fee47007"/>
+<approved hash="4,1,e6426521e5206643"/>
+<approved hash="4,1,ec7e535dd35c6c7f"/>
+<approved hash="4,1,d3ba5999d99853bb"/>
+<approved hash="4,1,d9f647d5c7d459f7"/>
+<approved hash="4,1,cf324e11ce104f33"/>
+<approved hash="4,1,28dd97fe17ffa8dc"/>
+<approved hash="4,1,05658b860b878564"/>
+<approved hash="4,1,a8260a5a8a61281d"/>
+<approved hash="4,1,d42c3650b657542b"/>
+<approved hash="4,1,6c19ce654e6bec17"/>
+<approved hash="4,1,83f6218aa19003ec"/>
+<approved hash="4,2,d51e1d1f9f1f571e"/>
+<approved hash="4,2,0db9efc96dce8fbe"/>
+<approved hash="4,2,d2777007f23c504c"/>
+<approved hash="4,2,ee410c318e366c46"/>
+<approved hash="4,2,167d940d16039473"/>
+<approved hash="4,2,d9865bf6d9ec5b9c"/>
+<approved hash="4,2,958c17fc95f21782"/>
+<approved hash="4,2,71b3d3c351f8f388"/>
+<approved hash="4,2,e2622a63a8636062"/>
+<approved hash="4,2,55e513e30c9ceb8a"/>
+<approved hash="4,2,f7423a43b8437542"/>
+<approved hash="4,2,8ad5a4be0d9f89f6"/>
+<approved hash="4,2,03c1cec04cc081c1"/>
+<approved hash="4,2,1805d9645b649a05"/>
+<approved hash="4,2,2e79d3585158ac79"/>
+<approved hash="4,2,249dec9c6e9ca69d"/>
+<approved hash="4,2,3ad1e6d064d0b8d1"/>
+<approved hash="4,2,3315f0347234b115"/>
+<approved hash="4,2,c9b60a9788974bb6"/>
+<approved hash="4,2,df52035381535d52"/>
+<approved hash="4,2,eada17fb95fb68da"/>
+<approved hash="4,2,e0e62187a38762e6"/>
+<approved hash="4,2,da2af441f7607309"/>
+<approved hash="4,2,3c5e46e947596135"/>
+<approved hash="4,2,defa1f9b9d9b5cfa"/>
+<approved hash="4,2,fc2e202fa22f7e2e"/>
+<approved hash="4,2,4af1f2f070f0c8f1"/>
+<approved hash="4,2,31bdfcbc7ebcb3bd"/>
+<approved hash="4,2,2619e7786578a419"/>
+<approved hash="4,2,2c25d1045304ae25"/>
+<approved hash="4,2,13e1dbe059e091e1"/>
+<approved hash="4,2,19adc5ac47ac9bad"/>
+<approved hash="4,2,0f49cc684e688d49"/>
+<approved hash="4,2,f5ea36cbb4cb77ea"/>
+<approved hash="4,2,e88615a797a76a86"/>
+<approved hash="4,2,c53e083f8a3f473e"/>
+<approved hash="4,2,a6a93a2e652fe620"/>
+<approved hash="4,15,f7423a43b8437542"/>
+<approved hash="4,15,8ad5a4be0d9f89f6"/>
+<approved hash="4,15,03c1cec04cc081c1"/>
+<approved hash="4,15,1805d9645b649a05"/>
+<approved hash="4,15,2e79d3585158ac79"/>
+<approved hash="4,15,249dec9c6e9ca69d"/>
+<approved hash="4,15,3ad1e6d064d0b8d1"/>
+<approved hash="4,15,3315f0347234b115"/>
+<approved hash="4,15,c9b60a9788974bb6"/>
+<approved hash="4,15,df52035381535d52"/>
+<approved hash="4,15,eada17fb95fb68da"/>
+<approved hash="4,15,e0e62187a38762e6"/>
+<approved hash="4,15,da2af441f7607309"/>
+<approved hash="4,15,3c5e46e947596135"/>
+<approved hash="4,15,defa1f9b9d9b5cfa"/>
+<approved hash="4,15,fc2e202fa22f7e2e"/>
+<approved hash="4,15,4af1f2f070f0c8f1"/>
+<approved hash="4,15,31bdfcbc7ebcb3bd"/>
+<approved hash="4,15,2619e7786578a419"/>
+<approved hash="4,15,2c25d1045304ae25"/>
+<approved hash="4,15,13e1dbe059e091e1"/>
+<approved hash="4,15,19adc5ac47ac9bad"/>
+<approved hash="4,15,0f49cc684e688d49"/>
+<approved hash="4,15,f5ea36cbb4cb77ea"/>
+<approved hash="4,15,e88615a797a76a86"/>
+<approved hash="4,15,c53e083f8a3f473e"/>
+<approved hash="4,15,96429621d455d436"/>
+<approved hash="4,15,337a4edb67b48186"/>
+<approved hash="4,15,75d4410b4168718f"/>
+<approved hash="4,15,9d39382f89d4eeb2"/>
+<approved hash="4,15,d51e1d1f9f1f571e"/>
+<approved hash="4,15,0db9efc96dce8fbe"/>
+<approved hash="4,15,d2777007f23c504c"/>
+<approved hash="4,15,ee410c318e366c46"/>
+<approved hash="4,15,167d940d16039473"/>
+<approved hash="4,15,d9865bf6d9ec5b9c"/>
+<approved hash="4,15,958c17fc95f21782"/>
+<approved hash="4,15,71b3d3c351f8f388"/>
+<approved hash="4,15,94d02c18bf5a75e8"/>
+<approved hash="4,15,73c22384b5b99481"/>
+<approved hash="4,15,e2622a63a8636062"/>
+<approved hash="4,15,55e513e30c9ceb8a"/>
+<approved hash="4,16,5744dd675d66d745"/>
+<approved hash="4,16,37d4d5a855afb7d3"/>
+<approved hash="4,16,a8260a5a8a61281d"/>
+<approved hash="4,16,d42c3650b657542b"/>
+<approved hash="4,16,6c19ce654e6bec17"/>
+<approved hash="4,16,83f6218aa19003ec"/>
+<approved hash="4,16,cfe86d94ed9a4fe6"/>
+<approved hash="4,16,0be2a99e29a58bd9"/>
+<approved hash="4,16,8ffce789bdb9acb7"/>
+<approved hash="4,16,2219a83a283ba218"/>
+<approved hash="4,16,7fba2d10ca37a2e0"/>
+<approved hash="4,16,74f8fa1b7a1af4f9"/>
+<approved hash="4,16,73d7aba0252937a1"/>
+<approved hash="4,16,819b0f788f79019a"/>
+<approved hash="4,16,9a5f193c993d1a5e"/>
+<approved hash="4,16,ac23130093012c22"/>
+<approved hash="4,16,a6e72cc4acc526e6"/>
+<approved hash="4,16,b8ab2688a68938aa"/>
+<approved hash="4,16,b16f304cb04d316e"/>
+<approved hash="4,16,4bcccaef4aeecbcd"/>
+<approved hash="4,16,5d08c32b432add09"/>
+<approved hash="4,16,6880d7a357a2e881"/>
+<approved hash="4,16,62bce1df61dee2bd"/>
+<approved hash="4,16,301eb798c8bc8d4a"/>
+<approved hash="4,16,cb29b35f5729e5a0"/>
+<approved hash="4,16,f514ae988257e3d9"/>
+<approved hash="4,16,1ea19dc21dc39ea0"/>
+<approved hash="4,16,3c55a2762277bc54"/>
+<approved hash="4,16,8aca70a9f0a80acb"/>
+<approved hash="4,16,f0067ee5fee47007"/>
+<approved hash="4,16,e6426521e5206643"/>
+<approved hash="4,16,ec7e535dd35c6c7f"/>
+<approved hash="4,16,d3ba5999d99853bb"/>
+<approved hash="4,16,d9f647d5c7d459f7"/>
+<approved hash="4,16,cf324e11ce104f33"/>
+<approved hash="4,16,3591b4b234b3b590"/>
+<approved hash="4,16,28dd97fe17ffa8dc"/>
+<approved hash="4,16,05658b860b878564"/>
+<approved hash="4,16,5d3722cd7de026d8"/>
+<approved hash="4,16,db41de020f76f8eb"/>
+<approved hash="4,16,bd1d246a7f63fd94"/>
+<approved hash="4,16,9fd9031e5a1fdf50"/>
+<approved hash="4,16,13059b76e0fdd8e2"/>
+<approved hash="4,16,8d54c88c687929a1"/>
+<approved hash="4,16,89a519c243dbc92c"/>
+<approved hash="4,16,fede16cae746ec47"/>
+<approved hash="4,16,8cdc8ff17c387525"/>
+<approved hash="4,16,d07530126aeb90fc"/>
+<approved hash="4,16,960d0d5a5453d684"/>
+<approved hash="4,16,fb6d7a14de93446a"/>
+<approved hash="4,16,56ba570a697468c4"/>
+<approved hash="4,16,30bcb47d10fab2b1"/>
+<approved hash="4,16,c6c54eacea2b78d2"/>
+<approved hash="4,1,5744dd675d66d745"/>
 </errors>
 </board>
 </drawing>

--- a/bloxa.brd
+++ b/bloxa.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.6.0">
+<eagle version="9.6.1">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -10940,6 +10940,21 @@
 <vertex x="9.7" y="-8"/>
 <vertex x="11.3" y="-8"/>
 </polygon>
+<contactref element="IC3" pad="8"/>
+<wire x1="-10.975" y1="-9.1" x2="-10.775" y2="-10.85" width="0" layer="19" extent="1-1"/>
+<wire x1="-7.125" y1="-7.8" x2="-10.625" y2="-8.25" width="0" layer="19" extent="16-16"/>
+<wire x1="-6.05" y1="-6.1" x2="-7.125" y2="-7.8" width="0" layer="19" extent="16-16"/>
+<wire x1="-5.8" y1="-4.3" x2="-6.05" y2="-6.1" width="0" layer="19" extent="1-1"/>
+<wire x1="-8" y1="-4.465" x2="-5.8" y2="-4.3" width="0" layer="19" extent="1-1"/>
+<wire x1="-2.8" y1="-3.195" x2="-5.8" y2="-4.3" width="0" layer="19" extent="1-1"/>
+<wire x1="-0.975" y1="-3.725" x2="-2.8" y2="-3.195" width="0" layer="19" extent="1-1"/>
+<wire x1="-1.2" y1="-4.85" x2="-0.975" y2="-3.725" width="0" layer="19" extent="1-1"/>
+<wire x1="-7.25" y1="-11.575" x2="-10.775" y2="-10.85" width="0" layer="19" extent="1-1"/>
+<wire x1="10.325" y1="-5.325" x2="0.175" y2="-3.625" width="0" layer="19" extent="1-1"/>
+<wire x1="10.4" y1="-6.1" x2="10.325" y2="-5.325" width="0" layer="19" extent="1-1"/>
+<wire x1="11" y1="-6.1" x2="10.4" y2="-6.1" width="0" layer="19" extent="1-1"/>
+<wire x1="10.425" y1="-7.33" x2="10.4" y2="-6.1" width="0" layer="19" extent="1-1"/>
+<wire x1="10.5" y1="-1.55" x2="10.325" y2="-5.325" width="0" layer="19" extent="1-16"/>
 </signal>
 <signal name="VDC" class="1">
 <contactref element="C9" pad="2"/>
@@ -11464,9 +11479,6 @@
 <wire x1="2.3" y1="5.9" x2="2.5" y2="5.7" width="0.2" layer="1"/>
 </signal>
 <signal name="USB_VBUS1">
-</signal>
-<signal name="N$2">
-<contactref element="IC3" pad="8"/>
 </signal>
 <signal name="N$4">
 <contactref element="LED3" pad="G"/>

--- a/bloxa.brd
+++ b/bloxa.brd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.6.1">
+<eagle version="9.3.1">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="mm" unit="mm" style="lines" multiple="2" display="no" altdistance="0.25" altunitdist="mm" altunit="mm"/>
+<grid distance="1" unitdist="mm" unit="mm" style="lines" multiple="2" display="no" altdistance="0.25" altunitdist="mm" altunit="mm"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="pwr" color="1" fill="3" visible="no" active="yes"/>
@@ -24,17 +24,17 @@
 <layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
 <layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
 <layer number="15" name="gnd" color="4" fill="6" visible="no" active="yes"/>
-<layer number="16" name="Bottom" color="9" fill="1" visible="yes" active="yes"/>
+<layer number="16" name="Bottom" color="9" fill="1" visible="no" active="yes"/>
 <layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="20" name="Dimension" color="15" fill="1" visible="yes" active="yes"/>
 <layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="yes"/>
 <layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
 <layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
 <layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
@@ -60,14 +60,13 @@
 <layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
 <layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="yes"/>
 <layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
 <layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
 <layer number="57" name="tCAD" color="12" fill="1" visible="no" active="no"/>
 <layer number="58" name="bCAD" color="9" fill="1" visible="no" active="no"/>
 <layer number="59" name="Invisible" color="7" fill="1" visible="no" active="no"/>
-<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
 <layer number="61" name="stand" color="7" fill="1" visible="no" active="no"/>
 <layer number="88" name="SimResults" color="9" fill="1" visible="no" active="no"/>
 <layer number="89" name="SimProbes" color="9" fill="1" visible="no" active="no"/>
@@ -100,8 +99,6 @@
 <layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
 <layer number="117" name="bMeasures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="yes"/>
-<layer number="119" name="KAP_TEKEN" color="7" fill="1" visible="no" active="no"/>
-<layer number="120" name="KAP_MAAT1" color="7" fill="1" visible="no" active="no"/>
 <layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
 <layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
 <layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
@@ -110,31 +107,18 @@
 <layer number="126" name="_bnames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="127" name="_tvalues" color="7" fill="1" visible="no" active="yes"/>
 <layer number="128" name="_bvalues" color="7" fill="1" visible="no" active="yes"/>
-<layer number="129" name="top_silk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="130" name="bLogo" color="7" fill="1" visible="no" active="yes"/>
 <layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
 <layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
-<layer number="133" name="bottom_silk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="134" name="silk_top" color="7" fill="1" visible="no" active="yes"/>
-<layer number="135" name="silk_bottom" color="7" fill="1" visible="no" active="yes"/>
-<layer number="136" name="silktop" color="7" fill="1" visible="no" active="yes"/>
-<layer number="137" name="silkbottom" color="7" fill="1" visible="no" active="yes"/>
-<layer number="138" name="EEE" color="7" fill="1" visible="no" active="yes"/>
-<layer number="139" name="_tKeepout" color="7" fill="1" visible="no" active="yes"/>
-<layer number="141" name="ASSEMBLY_TOP" color="7" fill="1" visible="no" active="yes"/>
-<layer number="143" name="PLACE_BOUND_TOP" color="7" fill="1" visible="no" active="yes"/>
 <layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
 <layer number="145" name="DrillLegend_01-16" color="2" fill="9" visible="no" active="yes"/>
 <layer number="146" name="DrillLegend_01-20" color="3" fill="9" visible="no" active="yes"/>
-<layer number="147" name="PIN_NUMBER" color="7" fill="1" visible="no" active="yes"/>
 <layer number="150" name="Notes" color="7" fill="1" visible="no" active="yes"/>
 <layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
 <layer number="152" name="_bDocu" color="7" fill="1" visible="no" active="yes"/>
 <layer number="153" name="FabDoc1" color="6" fill="1" visible="no" active="no"/>
 <layer number="154" name="FabDoc2" color="2" fill="1" visible="no" active="no"/>
 <layer number="155" name="FabDoc3" color="7" fill="15" visible="no" active="no"/>
-<layer number="166" name="AntennaArea" color="7" fill="1" visible="no" active="yes"/>
-<layer number="168" name="4mmHeightArea" color="7" fill="1" visible="no" active="yes"/>
 <layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
 <layer number="200" name="200bmp" color="1" fill="10" visible="no" active="yes"/>
 <layer number="201" name="201bmp" color="2" fill="10" visible="no" active="yes"/>
@@ -178,23 +162,26 @@
 <layer number="255" name="routoute" color="7" fill="1" visible="no" active="yes"/>
 </layers>
 <board>
-<fusionsync huburn="a.cGVyc29uYWw6dWUyYWE4ZDY4" projecturn="a.cGVyc29uYWw6dWUyYWE4ZDY4IzIwMTkwOTA2MjEzMTk3ODU2" f3durn="urn:adsk.wipprod:dm.lineage:t_abUf3MRzCdrWzT1gwKmQ" pcbguid="9a6ced3b-19a8-49ab-9ca9-3537635eed02" lastpulledtime="" lastsyncedchangeguid="" latestrevisionid="" lastsyncedrevisionid="" lastboardhashguid="9fee249a-4e12-b9c1-755d-a6b3befaaa10" lastpushedtime="2020-03-30T16:11:42Z" linktopcb3d="%12"/>
+<fusionsync huburn="a.cGVyc29uYWw6dWUyYWE4ZDY4" projecturn="a.cGVyc29uYWw6dWUyYWE4ZDY4IzIwMTgxMjA2MTY0MTQ2ODgx" f3durn="urn:adsk.wipprod:dm.lineage:vsyq4vMaSZ2FqqpQV7bhuQ" pcbguid="4b14bc76-6846-4836-9cfe-c4d4cdaa648d" lastpulledtime="" lastsyncedchangeguid="bc218286-cd5a-fab4-683b-a2897ab19400"/>
 <plain>
 <wire x1="-10.95" y1="-14.95" x2="10.95" y2="-14.95" width="0.01" layer="20" locked="yes"/>
 <wire x1="10.95" y1="-14.95" x2="12.45" y2="-13.45" width="0.01" layer="20" curve="90" locked="yes"/>
 <wire x1="12.45" y1="-13.45" x2="12.45" y2="17.15" width="0.01" layer="20" locked="yes"/>
 <wire x1="12.45" y1="17.15" x2="10.95" y2="18.65" width="0.01" layer="20" curve="90"/>
-<wire x1="10.95" y1="18.65" x2="-10.95" y2="18.65" width="0.01" layer="20"/>
+<wire x1="10.95" y1="18.65" x2="-10.85" y2="18.65" width="0.01" layer="20"/>
+<wire x1="-10.85" y1="18.65" x2="-10.95" y2="18.65" width="0.01" layer="20"/>
 <wire x1="-10.95" y1="18.65" x2="-12.45" y2="17.15" width="0.01" layer="20" curve="90"/>
 <wire x1="-12.45" y1="17.15" x2="-12.45" y2="-13.45" width="0.01" layer="20" locked="yes"/>
 <wire x1="-12.45" y1="-13.45" x2="-10.95" y2="-14.95" width="0.01" layer="20" curve="90" locked="yes"/>
-<text x="-5.45" y="-2.15" size="0.8" layer="1" font="vector" ratio="20" align="bottom-right">BLOXA 0.2</text>
+<text x="-5.25" y="-2.15" size="0.7" layer="1" font="vector" ratio="17" align="bottom-right">BLOXA 0.1</text>
 <text x="-8.35" y="16.8" size="0.6" layer="21" font="vector" ratio="15" align="center">C1</text>
 <text x="0" y="16.025" size="0.6" layer="21" font="vector" ratio="15" align="center">C2</text>
 <text x="8.4" y="16.8" size="0.6" layer="21" font="vector" ratio="15" align="center">C3</text>
 <text x="-6.525" y="17.925" size="0.6" layer="21" font="vector" ratio="15" align="center">+</text>
 <text x="1.8" y="17.25" size="0.6" layer="21" font="vector" ratio="15" align="center">+</text>
 <text x="10.125" y="17.775" size="0.6" layer="21" font="vector" ratio="15" align="center">+</text>
+<text x="14" y="-10" size="1.778" layer="1">Replace CON3 with SMD pads. 
+No TH components allowed here</text>
 </plain>
 <libraries>
 <library name="R_digikey" urn="urn:adsk.eagle:library:2539499">
@@ -260,10 +247,10 @@
 </library>
 <library name="PADS" urn="urn:adsk.eagle:library:3188696">
 <packages>
-<package name="SMD_1X1,5" urn="urn:adsk.eagle:footprint:7879125/1" library_version="21" library_locally_modified="yes">
+<package name="SMD_1X1,5" library_version="8" library_locally_modified="yes">
 <smd name="P$1" x="0" y="0" dx="1" dy="1.5" layer="1" roundness="25" rot="R180"/>
 </package>
-<package name="HOLE_0.6" urn="urn:adsk.eagle:footprint:6513717/2" library_version="21" library_locally_modified="yes">
+<package name="HOLE_0.6" urn="urn:adsk.eagle:footprint:6513717/1" locally_modified="yes" library_version="8" library_locally_modified="yes">
 <pad name="P$1" x="0" y="0" drill="0.6" shape="square"/>
 </package>
 <package name="4X2" urn="urn:adsk.eagle:footprint:3188701/1" library_version="7" library_locally_modified="yes">
@@ -278,16 +265,13 @@
 <wire x1="1.85" y1="1.2" x2="2.2" y2="0.85" width="0.1" layer="21" curve="-90"/>
 <text x="0" y="0" size="1.27" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
-<package name="HOLE_1.5" urn="urn:adsk.eagle:footprint:3332367/3" library_version="21" library_locally_modified="yes">
+<package name="HOLE_1.5" urn="urn:adsk.eagle:footprint:3332367/2" locally_modified="yes" library_version="8" library_locally_modified="yes">
 <pad name="P$1" x="0" y="0" drill="1.5" diameter="2.35"/>
 <text x="0" y="2.54" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
-<package name="1.5X1.5" urn="urn:adsk.eagle:footprint:15477726/1" library_version="21" library_locally_modified="yes">
-<smd name="P$1" x="0" y="0" dx="1.5" dy="1.5" layer="1" roundness="100"/>
-</package>
 </packages>
 <packages3d>
-<package3d name="HOLE_0.6" urn="urn:adsk.eagle:package:6513718/2" type="box" library_version="21" library_locally_modified="yes">
+<package3d name="HOLE_0.6" urn="urn:adsk.eagle:package:6513718/1" locally_modified="yes" type="box" library_version="8" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="HOLE_0.6"/>
 </packageinstances>
@@ -297,19 +281,9 @@
 <packageinstance name="4X2"/>
 </packageinstances>
 </package3d>
-<package3d name="HOLE_1.5" urn="urn:adsk.eagle:package:3332368/3" type="box" library_version="21" library_locally_modified="yes">
+<package3d name="HOLE_1.5" urn="urn:adsk.eagle:package:3332368/2" locally_modified="yes" type="box" library_version="8" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="HOLE_1.5"/>
-</packageinstances>
-</package3d>
-<package3d name="SMD_1X1,5" urn="urn:adsk.eagle:package:7879127/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="SMD_1X1,5"/>
-</packageinstances>
-</package3d>
-<package3d name="1.5X1.5" urn="urn:adsk.eagle:package:15477730/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="1.5X1.5"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -411,11 +385,43 @@
 <rectangle x1="-1.65" y1="-0.25" x2="-0.75" y2="0.25" layer="51"/>
 <circle x="-1" y="1.6" radius="0.111803125" width="0.1" layer="21"/>
 </package>
+<package name="LITE_ON_RGB_LED" urn="urn:adsk.eagle:footprint:1040103/1" library_version="1">
+<smd name="R" x="-0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="G" x="0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="+" x="-0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="B" x="0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
+<text x="0" y="1.75" size="0.6" layer="25" font="vector" ratio="15" rot="R180" align="center">&gt;NAME</text>
+<wire x1="-0.95" y1="1.35" x2="0.95" y2="1.35" width="0.1524" layer="21"/>
+<wire x1="0.95" y1="1.35" x2="0.95" y2="-1.35" width="0.1524" layer="21"/>
+<wire x1="0.95" y1="-1.35" x2="-0.95" y2="-1.35" width="0.1524" layer="21"/>
+<wire x1="-0.95" y1="-1.35" x2="-0.95" y2="1.35" width="0.1524" layer="21"/>
+<circle x="-1.25" y="1.25" radius="0.1" width="0.1524" layer="21"/>
+</package>
+<package name="0402_LED" urn="urn:adsk.eagle:footprint:1040136/1" library_version="1">
+<smd name="C" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="A" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-0.95" y1="0.5" x2="0.95" y2="0.5" width="0.15" layer="21"/>
+<wire x1="0.95" y1="0.5" x2="0.95" y2="-0.5" width="0.15" layer="21"/>
+<wire x1="0.95" y1="-0.5" x2="-0.95" y2="-0.5" width="0.15" layer="21"/>
+<wire x1="-0.95" y1="-0.5" x2="-0.95" y2="0.5" width="0.15" layer="21"/>
+<wire x1="-0.4" y1="0.5" x2="-0.4" y2="-0.5" width="0.15" layer="51"/>
+</package>
 </packages>
 <packages3d>
 <package3d name="SOT26" urn="urn:adsk.eagle:package:1040217/3" type="model" library_version="19">
 <packageinstances>
 <packageinstance name="SOT26"/>
+</packageinstances>
+</package3d>
+<package3d name="LITE_ON_RGB_LED" urn="urn:adsk.eagle:package:1040199/2" type="model" library_version="18">
+<packageinstances>
+<packageinstance name="LITE_ON_RGB_LED"/>
+</packageinstances>
+</package3d>
+<package3d name="0402_LED" urn="urn:adsk.eagle:package:1040216/2" type="model" library_version="15" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="0402_LED"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -598,18 +604,6 @@
 <circle x="0" y="0" radius="1.5" width="0.127" layer="41"/>
 <smd name="P$1" x="0" y="0" dx="1.016" dy="1.016" layer="1" roundness="100" cream="no"/>
 </package>
-<package name="0606" urn="urn:adsk.eagle:footprint:20072924/1" library_version="83" library_locally_modified="yes">
-<circle x="-1.25" y="1.25" radius="0.1" width="0.1524" layer="21"/>
-<wire x1="-0.95" y1="1.35" x2="0.95" y2="1.35" width="0.1524" layer="21"/>
-<wire x1="0.95" y1="1.35" x2="0.95" y2="-1.35" width="0.1524" layer="21"/>
-<wire x1="0.95" y1="-1.35" x2="-0.95" y2="-1.35" width="0.1524" layer="21"/>
-<wire x1="-0.95" y1="-1.35" x2="-0.95" y2="1.35" width="0.1524" layer="21"/>
-<smd name="+" x="-0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="B" x="0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="G" x="0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="R" x="-0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
-<text x="0" y="1.75" size="0.6" layer="25" font="vector" ratio="15" rot="R180" align="center">&gt;NAME</text>
-</package>
 </packages>
 <packages3d>
 <package3d name="SENSE-0.6" urn="urn:adsk.eagle:package:7365871/1" type="box" library_version="8">
@@ -625,11 +619,6 @@
 <package3d name="CONNECTION" urn="urn:adsk.eagle:package:7439847/1" type="box" library_version="9">
 <packageinstances>
 <packageinstance name="CONNECTION"/>
-</packageinstances>
-</package3d>
-<package3d name="0606" urn="urn:adsk.eagle:package:20072926/2" type="model" library_version="83" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="0606"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -675,35 +664,6 @@
 <wire x1="-4" y1="23.5" x2="4" y2="23.5" width="0.1" layer="51"/>
 <wire x1="4" y1="23.5" x2="4" y2="2" width="0.1" layer="51"/>
 </package>
-<package name="R0402" urn="urn:adsk.eagle:footprint:2539434/1" library_version="46" library_locally_modified="yes">
-<smd name="1" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<smd name="2" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="12" align="center">&gt;NAME</text>
-<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
-<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
-<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
-<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
-<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
-<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
-<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
-<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
-</package>
-<package name="LED0402" urn="urn:adsk.eagle:footprint:2539447/1" library_version="54">
-<smd name="A" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<smd name="C" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<text x="0" y="0" size="0.4064" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
-<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
-<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
-<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
-<wire x1="-0.9" y1="0.45" x2="0.1" y2="0.45" width="0.1" layer="21"/>
-<wire x1="0.1" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
-<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
-<wire x1="0.9" y1="-0.45" x2="0.1" y2="-0.45" width="0.1" layer="21"/>
-<wire x1="0.1" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
-<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
-<wire x1="0.1" y1="0.45" x2="0.1" y2="-0.45" width="0.1" layer="21"/>
-</package>
 </packages>
 <packages3d>
 <package3d name="RADIAL_SIDE_8X21.5" urn="urn:adsk.eagle:package:7189333/3" type="model" library_version="29" library_locally_modified="yes">
@@ -711,14 +671,36 @@
 <packageinstance name="RADIAL_SIDE_8X21.5"/>
 </packageinstances>
 </package3d>
-<package3d name="R0402" urn="urn:adsk.eagle:package:2539456/2" type="model" library_version="46" library_locally_modified="yes">
+</packages3d>
+</library>
+<library name="pinhead" urn="urn:adsk.eagle:library:2540341">
+<packages>
+<package name="1X02-PTH-2.54" urn="urn:adsk.eagle:footprint:2540357/1" library_version="30">
+<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="0.635" x2="-2.54" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-1.905" y1="1.27" x2="-2.54" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="-0.635" x2="-1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="-1.27" y="0" drill="1" diameter="1.7" rot="R90"/>
+<pad name="2" x="1.27" y="0" drill="1" diameter="1.7" rot="R90"/>
+<text x="0" y="0" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="37"/>
+<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="37"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="1X02-PTH-2.54" urn="urn:adsk.eagle:package:2540385/2" type="model" library_version="30">
 <packageinstances>
-<packageinstance name="R0402"/>
-</packageinstances>
-</package3d>
-<package3d name="LED0402" urn="urn:adsk.eagle:package:2539470/2" type="model" library_version="54">
-<packageinstances>
-<packageinstance name="LED0402"/>
+<packageinstance name="1X02-PTH-2.54"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -9774,47 +9756,47 @@
 </pass>
 </autorouter>
 <elements>
-<element name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-5" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-7" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="-9" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="13" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="11" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="9" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="7" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="5" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="3" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="1" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-1" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-3" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-5" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-7" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-9" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-11" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-12.45" y="-13" locked="yes" smashed="yes" rot="MR0"/>
-<element name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-9" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-7" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="-5" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="3" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="5" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="7" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="9" y="-14.95" smashed="yes" rot="MR0"/>
-<element name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-13" smashed="yes" rot="MR0"/>
-<element name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-11" smashed="yes" rot="MR0"/>
-<element name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-9" smashed="yes" rot="MR0"/>
-<element name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-7" smashed="yes" rot="MR0"/>
-<element name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-5" smashed="yes" rot="MR0"/>
-<element name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-3" smashed="yes" rot="MR0"/>
-<element name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="-1" smashed="yes" rot="MR0"/>
-<element name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="1" smashed="yes" rot="MR0"/>
-<element name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="3" smashed="yes" rot="MR0"/>
-<element name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="5" smashed="yes" rot="MR0"/>
-<element name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="7" smashed="yes" rot="MR0"/>
-<element name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="9" smashed="yes" rot="MR0"/>
-<element name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/2" value="PAD-HOLE-0.6" x="12.45" y="11" smashed="yes" rot="MR0"/>
-<element name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="9" y="14.95" smashed="yes" rot="MR0"/>
-<element name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="7" y="14.95" smashed="yes" rot="MR0"/>
-<element name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="5" y="14.95" smashed="yes" rot="MR0"/>
-<element name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5" x="3" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="-5" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="-7" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="-9" y="14.95" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="13" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="11" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="9" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="7" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="5" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="3" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="1" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-1" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-3" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-5" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-7" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-9" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-11" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-12.45" y="-13" locked="yes" smashed="yes" rot="MR0"/>
+<element name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-9" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-7" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="-5" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="3" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="5" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="7" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="9" y="-14.95" smashed="yes" rot="MR0"/>
+<element name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-13" smashed="yes" rot="MR0"/>
+<element name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-11" smashed="yes" rot="MR0"/>
+<element name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-9" smashed="yes" rot="MR0"/>
+<element name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-7" smashed="yes" rot="MR0"/>
+<element name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-5" smashed="yes" rot="MR0"/>
+<element name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-3" smashed="yes" rot="MR0"/>
+<element name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="-1" smashed="yes" rot="MR0"/>
+<element name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="1" smashed="yes" rot="MR0"/>
+<element name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="3" smashed="yes" rot="MR0"/>
+<element name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="5" smashed="yes" rot="MR0"/>
+<element name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="7" smashed="yes" rot="MR0"/>
+<element name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="9" smashed="yes" rot="MR0"/>
+<element name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_0.6" package3d_urn="urn:adsk.eagle:package:6513718/1" value="PAD-HOLE-0.6" x="12.45" y="11" smashed="yes" rot="MR0"/>
+<element name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="9" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="7" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="5" y="14.95" smashed="yes" rot="MR0"/>
+<element name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="SMD_1X1,5" value="PAD-1X1.5" x="3" y="14.95" smashed="yes" rot="MR0"/>
 <element name="C10" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" package="C0402" package3d_urn="urn:adsk.eagle:package:2539379/2" value="0.1µF" x="-9.95" y="-5.05" smashed="yes" rot="R90">
 <attribute name="DIGIKEY#" value="490-3261-1-ND" x="109.05" y="-49.05" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="MANF" value="Murata Electronics North America" x="109.05" y="-49.05" size="1.778" layer="27" rot="R90" display="off"/>
@@ -9893,18 +9875,18 @@
 <attribute name="VALUE" x="3.55" y="-6.55" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 <attribute name="VOLTAGE" value="25V" x="187.45" y="-17.55" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="LED4" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="0606" package3d_urn="urn:adsk.eagle:package:20072926/2" value="LTST-C19HE1WT" x="10.45" y="-13" smashed="yes" rot="R270">
+<element name="LED4" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="LITE_ON_RGB_LED" package3d_urn="urn:adsk.eagle:package:1040199/2" value="LTST-C19HE1WT" x="10.45" y="-13" smashed="yes" rot="R270">
 <attribute name="DIGIKEY#" value="160-2162-1-ND" x="-184.55" y="-9" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="MANF" value="Lite-On Inc" x="-184.55" y="-9" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="MANF#" value="LTST-C19HE1WT" x="-184.55" y="-9" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="NAME" x="10.575" y="-13" size="0.6" layer="25" font="vector" ratio="15" rot="R180" align="center"/>
 </element>
-<element name="LED2" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="LED0402" package3d_urn="urn:adsk.eagle:package:2539470/2" value="GREEN" x="-10.45" y="-13.75" smashed="yes" rot="R180">
-<attribute name="COLOR" value="GREEN" x="6.55" y="176.25" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="DIGIKEY#" value="1830-IN-S42BT5GCT-ND" x="6.55" y="176.25" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="MANF" value="Inolux" x="6.55" y="176.25" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="MANF#" value="IN-S42BT5G" x="6.55" y="176.25" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="NAME" x="-10.45" y="-13.75" size="0.4064" layer="25" font="vector" ratio="15" rot="R180" align="center"/>
+<element name="LED2" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="0402_LED" package3d_urn="urn:adsk.eagle:package:1040216/2" value="GREEN" x="-10.45" y="-13.75" smashed="yes">
+<attribute name="COLOR" value="GREEN" x="-27.45" y="-203.75" size="1.778" layer="27" display="off"/>
+<attribute name="DIGIKEY#" value="511-1652-1-ND" x="-27.45" y="-203.75" size="1.778" layer="27" display="off"/>
+<attribute name="MANF" value="Rohm Semiconductor" x="-27.45" y="-203.75" size="1.778" layer="27" display="off"/>
+<attribute name="MANF#" value="SML-P11MTT86" x="-27.45" y="-203.75" size="1.778" layer="27" display="off"/>
+<attribute name="NAME" x="-10.45" y="-14.65" size="0.5" layer="25" font="vector" ratio="15" align="center"/>
 </element>
 <element name="R5" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" package="R0402" package3d_urn="urn:adsk.eagle:package:2539512/2" value="1K" x="7.4" y="-6.975" smashed="yes" rot="R90">
 <attribute name="DIGIKEY#" value="311-1.00KLRCT-ND" x="206.4" y="-62.975" size="1.778" layer="27" rot="R90" display="off"/>
@@ -9942,13 +9924,13 @@
 <attribute name="TOLERANCE" value="1%" x="39.55" y="195.85" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="VALUE" x="-10.45" y="-13.05" size="0.5" layer="27" font="vector" ratio="15" rot="R180" align="center"/>
 </element>
-<element name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="-4" y="17.15" smashed="yes">
+<element name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5" x="-4" y="17.15" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="-11" y="24.15" size="1.778" layer="27" display="off"/>
 </element>
-<element name="R4" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="10 mOhms" x="-4.5" y="1.375" locked="yes" smashed="yes">
-<attribute name="DIGIKEY#" value="CSNL2512FT10L0CT-ND" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
-<attribute name="MANF" value="Stackpole Electronics Inc" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
-<attribute name="MANF#" value="CSNL2512FT10L0" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
+<element name="R4" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="5 mOhms" x="-4.5" y="1.375" locked="yes" smashed="yes">
+<attribute name="DIGIKEY#" value="CSNL2512FT5L00CT-ND" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
+<attribute name="MANF" value="Stackpole Electronics Inc." x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
+<attribute name="MANF#" value="CSNL2512FT5L00" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
 <attribute name="NAME" x="-4.5" y="1.375" size="1.5" layer="25" font="vector" ratio="15" align="center"/>
 <attribute name="POWER" value="2W" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
 <attribute name="TC" value="±50ppm/°C" x="-4.5" y="10.375" size="1.778" layer="27" display="off"/>
@@ -9990,13 +9972,13 @@
 <attribute name="TOLERANCE" value="5%" x="-7.05" y="-11.8" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="VALUE" x="-7.95" y="5.2" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="0" y="17.15" smashed="yes" rot="R270">
+<element name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5" x="0" y="17.15" smashed="yes" rot="R270">
 <attribute name="BOM" value="EXCLUDE" x="-18" y="27.15" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="R10" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="10 mOhms" x="4.5" y="1.375" locked="yes" smashed="yes">
-<attribute name="DIGIKEY#" value="CSNL2512FT10L0CT-ND" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
-<attribute name="MANF" value="Stackpole Electronics Inc" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
-<attribute name="MANF#" value="CSNL2512FT10L0" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
+<element name="R10" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" package="R2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" value="5 mOhms" x="4.5" y="1.375" locked="yes" smashed="yes">
+<attribute name="DIGIKEY#" value="CSNL2512FT5L00CT-ND" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
+<attribute name="MANF" value="Stackpole Electronics Inc." x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
+<attribute name="MANF#" value="CSNL2512FT5L00" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
 <attribute name="NAME" x="4.5" y="1.375" size="1.5" layer="25" font="vector" ratio="15" align="center"/>
 <attribute name="POWER" value="2W" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
 <attribute name="TC" value="±50ppm/°C" x="-4.5" y="-14.625" size="1.778" layer="27" display="off"/>
@@ -10020,7 +10002,7 @@
 <attribute name="TOLERANCE" value="5%" x="12.5" y="5.2" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="VALUE" x="1.6" y="5.2" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5" x="4" y="17.15" smashed="yes">
+<element name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5" x="4" y="17.15" smashed="yes">
 <attribute name="BOM" value="EXCLUDE" x="-9" y="-15.85" size="1.778" layer="27" display="off"/>
 </element>
 <element name="R11" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" package="R0402" package3d_urn="urn:adsk.eagle:package:2539512/2" value="4R3" x="8.65" y="5.2" smashed="yes" rot="R90">
@@ -10115,10 +10097,10 @@
 <element name="PAD42" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="4X2" package3d_urn="urn:adsk.eagle:package:3188708/1" value="PAD-4X2" x="-10.5" y="1.4" locked="yes" smashed="yes" rot="R90">
 <attribute name="BOM" value="EXCLUDE" x="-10.5" y="1.4" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="D1" library="TVS_diodes" library_urn="urn:adsk.eagle:library:3333632" package="SOD128" package3d_urn="urn:adsk.eagle:package:6533206/2" value="PTVS33VP1UTP,115-36V-SOD128" x="6.95" y="-2.85" smashed="yes" rot="R180">
-<attribute name="DIGIKEY#" value="1727-1411-1-ND" x="60.45" y="-15.35" size="1.778" layer="27" rot="R180" display="off"/>
+<element name="D1" library="TVS_diodes" library_urn="urn:adsk.eagle:library:3333632" package="SOD128" package3d_urn="urn:adsk.eagle:package:6533206/2" value="PTVS36VP1UP,115-36V-SOD128" x="6.95" y="-2.85" smashed="yes" rot="R180">
+<attribute name="DIGIKEY#" value="1727-4439-2-ND" x="60.45" y="-15.35" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="MANF" value="Nexperia USA Inc" x="60.45" y="-15.35" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="MANF#" value="PTVS33VP1UTP,115" x="60.45" y="-15.35" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="MANF#" value="PTVS36VP1UP,115" x="60.45" y="-15.35" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="NAME" x="6.95" y="-2.85" size="1" layer="25" font="vector" ratio="15" align="center"/>
 </element>
 <element name="C1" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="RADIAL_SIDE_8X21.5" package3d_urn="urn:adsk.eagle:package:7189333/3" value="180µF" x="-8.4" y="16.8" locked="yes" smashed="yes" rot="R180">
@@ -10144,6 +10126,9 @@
 <attribute name="NAME" x="0" y="16" size="1" layer="25" font="vector" ratio="15" rot="R180" align="center"/>
 <attribute name="PACKAGE" value="RADIAL" x="8.15" y="-8.4" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="VOLTAGE" value="50V" x="8.15" y="-8.4" size="1.778" layer="27" rot="R180" display="off"/>
+</element>
+<element name="CON3" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" package="1X02-PTH-2.54" package3d_urn="urn:adsk.eagle:package:2540385/2" value="PINHEAD_1X02-2.54" x="10.425" y="-8.6" smashed="yes" rot="R270">
+<attribute name="NAME" x="10.425" y="-8.6" size="1" layer="25" font="vector" ratio="15" rot="R270" align="center"/>
 </element>
 <element name="IC3" library="serial_interfaces" library_urn="urn:adsk.eagle:library:4770999" package="SOIC8" package3d_urn="urn:adsk.eagle:package:4771007/3" value="TJA1051(X)/3-SO8" x="-5.4" y="-5.1" smashed="yes">
 <attribute name="DIGIKEY#" value="568-8684-2-ND" x="-5.4" y="-5.1" size="1.778" layer="27" display="off"/>
@@ -10177,30 +10162,28 @@
 <element name="J1" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="CONNECTION" package3d_urn="urn:adsk.eagle:package:7439847/1" value="CONNECTION" x="10.5" y="-1.2" smashed="yes" rot="MR90">
 <attribute name="BOM" value="EXCLUDE" x="10.5" y="-1.2" size="1.778" layer="28" rot="MR90" display="off"/>
 </element>
-<element name="LED1" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="LED0402" package3d_urn="urn:adsk.eagle:package:2539470/2" value="GREEN" x="-2.425" y="-14.05" smashed="yes" rot="MR0">
-<attribute name="COLOR" value="" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR0" display="off"/>
-<attribute name="DIGIKEY#" value="" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR0" display="off"/>
-<attribute name="MANF" value="" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR0" display="off"/>
-<attribute name="MANF#" value="" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR0" display="off"/>
-<attribute name="NAME" x="-2.425" y="-14.05" size="0.5" layer="26" font="vector" ratio="15" rot="MR0" align="center"/>
+<element name="LED1" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="0402_LED" package3d_urn="urn:adsk.eagle:package:1040216/2" value="GREEN" x="-2.425" y="-14.05" smashed="yes" rot="MR180">
+<attribute name="COLOR" value="GREEN" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
+<attribute name="DIGIKEY#" value="511-1652-1-ND" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
+<attribute name="MANF" value="Rohm Semiconductor" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
+<attribute name="MANF#" value="SML-P11MTT86" x="-2.425" y="-14.05" size="1.778" layer="28" rot="MR180" display="off"/>
+<attribute name="NAME" x="-2.425" y="-14.05" size="0.5" layer="26" font="vector" ratio="15" rot="MR180" align="center"/>
 </element>
-<element name="LED3" library="misc" library_urn="urn:adsk.eagle:library:5347860" package="0606" package3d_urn="urn:adsk.eagle:package:20072926/2" value="LTST-C19HE1WT" x="0.5" y="-13.3" smashed="yes" rot="MR180">
+<element name="LED3" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" package="LITE_ON_RGB_LED" package3d_urn="urn:adsk.eagle:package:1040199/2" value="LTST-C19HE1WT" x="0.5" y="-13.3" smashed="yes" rot="MR180">
 <attribute name="DIGIKEY#" value="160-2162-1-ND" x="0.5" y="-13.3" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="MANF" value="Lite-On Inc" x="0.5" y="-13.3" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="MANF#" value="LTST-C19HE1WT" x="0.5" y="-13.3" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="NAME" x="0.5" y="-15.05" size="0.6" layer="26" font="vector" ratio="15" rot="MR0" align="center"/>
 </element>
-<element name="R14" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="R0402" package3d_urn="urn:adsk.eagle:package:2539456/2" value="680R" x="10.825" y="-5.325" smashed="yes">
-<attribute name="AEC-Q" value="AEC-Q200" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
-<attribute name="DIGIKEY#" value="CRCW0402680RFKEDDatasheet " x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
-<attribute name="MANF" value="Vishay Dale" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
-<attribute name="MANF#" value="CRCW0402680RFKED" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
+<element name="R14" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" package="R0402" package3d_urn="urn:adsk.eagle:package:2539512/2" value="1K" x="10.825" y="-5.325" smashed="yes">
+<attribute name="DIGIKEY#" value="311-1.00KLRCT-ND" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
+<attribute name="MANF" value="Yageo" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
+<attribute name="MANF#" value="RC0402FR-071KL" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
 <attribute name="NAME" x="10.825" y="-5.325" size="0.5" layer="25" font="vector" ratio="15" align="center"/>
 <attribute name="PACKAGE" value="0402" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
 <attribute name="TOLERANCE" value="1%" x="10.825" y="-5.325" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" x="10.825" y="-4.425" size="0.5" layer="27" font="vector" ratio="15" align="center"/>
 </element>
-<element name="PAD47" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="1.5X1.5" package3d_urn="urn:adsk.eagle:package:15477730/1" value="PAD-S-1.5" x="10.425" y="-7.33" smashed="yes"/>
-<element name="PAD48" library="PADS" library_urn="urn:adsk.eagle:library:3188696" package="1.5X1.5" package3d_urn="urn:adsk.eagle:package:15477730/1" value="PAD-S-1.5" x="10.425" y="-9.87" smashed="yes"/>
 </elements>
 <signals>
 <signal name="PHASE_A_GND">
@@ -10516,9 +10499,9 @@
 <wire x1="-8" y1="-3.195" x2="-7.65" y2="-3.195" width="0.15" layer="1"/>
 <wire x1="0.575" y1="-1" x2="0.575" y2="-1.15" width="0.15" layer="1"/>
 <wire x1="0.575" y1="-1.15" x2="0.225" y2="-1.5" width="0.15" layer="1"/>
-<wire x1="0.225" y1="-1.5" x2="-3.95" y2="-1.5" width="0.15" layer="1"/>
-<wire x1="-3.95" y1="-1.5" x2="-5.65" y2="-3.2" width="0.15" layer="1"/>
-<wire x1="-5.65" y1="-3.2" x2="-7.65" y2="-3.2" width="0.15" layer="1"/>
+<wire x1="0.225" y1="-1.5" x2="-3.45" y2="-1.5" width="0.15" layer="1"/>
+<wire x1="-3.45" y1="-1.5" x2="-5.15" y2="-3.2" width="0.15" layer="1"/>
+<wire x1="-5.15" y1="-3.2" x2="-7.65" y2="-3.2" width="0.15" layer="1"/>
 <via x="0.575" y="-1" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="-7.65" y1="-3.195" x2="-7.65" y2="-3.2" width="0.15" layer="1"/>
 <wire x1="2.7" y1="2.95" x2="0.825" y2="1.075" width="0.15" layer="16"/>
@@ -10529,10 +10512,13 @@
 <signal name="RGB_LED_R">
 <contactref element="PAD12" pad="P$1"/>
 <contactref element="R7" pad="2"/>
+<wire x1="12.45" y1="-3" x2="12.2" y2="-3" width="0.15" layer="1"/>
+<wire x1="12.2" y1="-3" x2="12.07" y2="-3" width="0.15" layer="1"/>
+<wire x1="12.07" y1="-3" x2="11.975" y2="-3" width="0.15" layer="1"/>
 <wire x1="9.3" y1="-5.325" x2="9.9" y2="-4.725" width="0.15" layer="1"/>
 <wire x1="9.9" y1="-4.725" x2="10.2485375" y2="-4.725" width="0.15" layer="1"/>
-<wire x1="11.9735375" y1="-3" x2="10.2485375" y2="-4.725" width="0.15" layer="1"/>
-<wire x1="12.45" y1="-3" x2="11.9735375" y2="-3" width="0.15" layer="1"/>
+<wire x1="11.9735375" y1="-3" x2="12.07" y2="-3" width="0.15" layer="1"/>
+<wire x1="10.2485375" y1="-4.725" x2="11.9735375" y2="-3" width="0.15" layer="1"/>
 </signal>
 <signal name="RGB_LED_G">
 <contactref element="PAD11" pad="P$1"/>
@@ -10553,6 +10539,7 @@
 <wire x1="12.45" y1="1" x2="12.45" y2="0.975" width="0.15" layer="1"/>
 <wire x1="12.45" y1="0.975" x2="11.775" y2="0.3" width="0.15" layer="1"/>
 <wire x1="11.775" y1="-1.175" x2="11.225" y2="-1.725" width="0.15" layer="1"/>
+<wire x1="7.45" y1="-6.475" x2="7.4" y2="-6.475" width="0.15" layer="1"/>
 <wire x1="11.225" y1="-1.725" x2="11.225" y2="-2.9" width="0.15" layer="1"/>
 <wire x1="11.225" y1="-2.9" x2="10" y2="-4.125" width="0.15" layer="1"/>
 <wire x1="7.4" y1="-4.7" x2="7.4" y2="-6.475" width="0.15" layer="1"/>
@@ -10561,10 +10548,11 @@
 </signal>
 <signal name="GPIO1">
 <contactref element="PAD14" pad="P$1"/>
-<wire x1="12.45" y1="-7" x2="11.7" y2="-7.75" width="0.15" layer="1"/>
-<wire x1="11.7" y1="-7.75" x2="11.7" y2="-8.595" width="0.15" layer="1"/>
-<contactref element="PAD48" pad="P$1"/>
-<wire x1="11.7" y1="-8.595" x2="10.425" y2="-9.87" width="0.15" layer="1"/>
+<contactref element="CON3" pad="2"/>
+<wire x1="10.425" y1="-9.87" x2="11.6" y2="-8.695" width="0.15" layer="1"/>
+<wire x1="11.6" y1="-8.695" x2="11.6" y2="-8.6" width="0.15" layer="1"/>
+<wire x1="12.45" y1="-7" x2="11.6" y2="-7.85" width="0.15" layer="1"/>
+<wire x1="11.6" y1="-7.85" x2="11.6" y2="-8.6" width="0.15" layer="1"/>
 </signal>
 <signal name="USART_TX">
 <contactref element="PAD19" pad="P$1"/>
@@ -10587,11 +10575,13 @@
 <wire x1="3.025" y1="13.375" x2="3.025" y2="2.85" width="0.15" layer="16"/>
 <wire x1="1.325" y1="-1.15" x2="1.325" y2="-1" width="0.15" layer="1"/>
 <wire x1="1.325" y1="-1.15" x2="0.625" y2="-1.85" width="0.15" layer="1"/>
-<wire x1="0.625" y1="-1.85" x2="-3.75" y2="-1.85" width="0.15" layer="1"/>
+<wire x1="0.625" y1="-1.85" x2="-3.3" y2="-1.85" width="0.15" layer="1"/>
 <wire x1="1.175" y1="-0.85" x2="1.325" y2="-1" width="0.15" layer="16"/>
 <wire x1="1.175" y1="1" x2="1.175" y2="-0.85" width="0.15" layer="16"/>
-<wire x1="-3.75" y1="-1.85" x2="-6.65" y2="-4.75" width="0.15" layer="1"/>
-<wire x1="-6.65" y1="-4.75" x2="-6.65" y2="-6.5" width="0.15" layer="1"/>
+<wire x1="-3.3" y1="-1.85" x2="-4.95" y2="-3.5" width="0.15" layer="1"/>
+<wire x1="-4.95" y1="-3.5" x2="-5.9" y2="-3.5" width="0.15" layer="1"/>
+<wire x1="-5.9" y1="-3.5" x2="-6.65" y2="-4.25" width="0.15" layer="1"/>
+<wire x1="-6.65" y1="-4.25" x2="-6.65" y2="-6.5" width="0.15" layer="1"/>
 </signal>
 <signal name="VDD_5V">
 <contactref element="PAD22" pad="P$1"/>
@@ -10717,10 +10707,9 @@
 <signal name="OVERCURRENT_PROTECT_ADJ">
 <contactref element="PAD13" pad="P$1"/>
 <contactref element="R14" pad="2"/>
-<wire x1="12.45" y1="-5" x2="12.45" y2="-5.2" width="0.3" layer="1"/>
-<wire x1="12.45" y1="-5.2" x2="12.375" y2="-5.275" width="0.3" layer="1"/>
+<wire x1="12.45" y1="-5" x2="12.175" y2="-5.275" width="0.3" layer="1"/>
 <wire x1="11.375" y1="-5.275" x2="11.325" y2="-5.325" width="0.3" layer="1"/>
-<wire x1="12.375" y1="-5.275" x2="11.375" y2="-5.275" width="0.3" layer="1"/>
+<wire x1="12.175" y1="-5.275" x2="11.375" y2="-5.275" width="0.3" layer="1"/>
 </signal>
 <signal name="USB+">
 <contactref element="PAD7" pad="P$1"/>
@@ -10768,18 +10757,19 @@
 <wire x1="3.45" y1="-2.125" x2="1.95" y2="-2.125" width="0.15" layer="1"/>
 <wire x1="3.45" y1="-2.125" x2="3.7" y2="-2.375" width="0.15" layer="1"/>
 <wire x1="3.7" y1="-2.375" x2="3.7" y2="-4.05" width="0.15" layer="1"/>
+<wire x1="7.575" y1="-11.325" x2="7.575" y2="-8.7" width="0.15" layer="1"/>
 <wire x1="7.87825" y1="-14.515" x2="7.575" y2="-14.21175" width="0.15" layer="1"/>
-<wire x1="7.575" y1="-8.7" x2="7.575" y2="-14.21175" width="0.15" layer="1"/>
+<wire x1="7.575" y1="-11.325" x2="7.575" y2="-14.21175" width="0.15" layer="1"/>
 <wire x1="9" y1="-14.95" x2="8.565" y2="-14.515" width="0.15" layer="1"/>
 <wire x1="8.565" y1="-14.515" x2="7.87825" y2="-14.515" width="0.15" layer="1"/>
 <wire x1="1.95" y1="-2.125" x2="1.6" y2="-2.475" width="0.15" layer="1"/>
 <wire x1="0.375" y1="-2.475" x2="0.175" y2="-2.675" width="0.15" layer="1"/>
 <wire x1="1.6" y1="-2.475" x2="0.375" y2="-2.475" width="0.15" layer="1"/>
 <wire x1="7.575" y1="-8.7" x2="6.825" y2="-7.95" width="0.15" layer="1"/>
-<wire x1="6.825" y1="-6.3" x2="5.35" y2="-4.825" width="0.15" layer="1"/>
-<wire x1="5.35" y1="-4.825" x2="4.475" y2="-4.825" width="0.15" layer="1"/>
-<wire x1="4.475" y1="-4.825" x2="3.7" y2="-4.05" width="0.15" layer="1"/>
-<wire x1="6.825" y1="-7.95" x2="6.825" y2="-6.3" width="0.15" layer="1"/>
+<wire x1="6.825" y1="-6" x2="5.85" y2="-5.025" width="0.15" layer="1"/>
+<wire x1="5.85" y1="-5.025" x2="4.675" y2="-5.025" width="0.15" layer="1"/>
+<wire x1="4.675" y1="-5.025" x2="3.7" y2="-4.05" width="0.15" layer="1"/>
+<wire x1="6.825" y1="-7.95" x2="6.825" y2="-6" width="0.15" layer="1"/>
 </signal>
 <signal name="PHASE_C_GND">
 <contactref element="PAD36" pad="P$1"/>
@@ -10913,6 +10903,7 @@
 <wire x1="-8" y1="-4.465" x2="-9.865" y2="-4.465" width="0.4" layer="1"/>
 <wire x1="-9.865" y1="-4.465" x2="-9.95" y2="-4.55" width="0.4" layer="1"/>
 <contactref element="C11" pad="2"/>
+<contactref element="CON3" pad="1"/>
 <polygon width="0.15" layer="15" rank="4">
 <vertex x="-12.45" y="1.95"/>
 <vertex x="12.45" y="1.95"/>
@@ -10939,26 +10930,14 @@
 <wire x1="-0.875" y1="-3.625" x2="-0.975" y2="-3.725" width="0.3" layer="1"/>
 <via x="-10.775" y="-10.85" extent="1-16" drill="0.3" diameter="0.6"/>
 <via x="-7.25" y="-11.575" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-5.8" y="-4.3" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-6.05" y="-6.1" extent="1-16" drill="0.3" diameter="0.6"/>
 <via x="-10.625" y="-8.25" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="-10.975" y1="-9.1" x2="-10.625" y2="-8.75" width="0.15" layer="1"/>
 <wire x1="-10.625" y1="-8.75" x2="-10.625" y2="-8.25" width="0.15" layer="1"/>
 <contactref element="R14" pad="1"/>
-<contactref element="PAD47" pad="P$1"/>
-<via x="10.4" y="-6.1" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="11" y="-6.1" extent="1-16" drill="0.3" diameter="0.6"/>
-<polygon width="0.2" layer="1" thermals="no">
-<vertex x="11.3" y="-5.8"/>
-<vertex x="10.6" y="-5.8"/>
-<vertex x="10.6" y="-5.1"/>
-<vertex x="9.7" y="-5.1"/>
-<vertex x="9.7" y="-8"/>
-<vertex x="11.3" y="-8"/>
-</polygon>
-<contactref element="IC3" pad="8"/>
-<via x="-4.6" y="-3.8" extent="1-16" drill="0.3" diameter="0.6"/>
-<wire x1="-2.8" y1="-3.195" x2="-2.9" y2="-3.295" width="0.3" layer="1"/>
-<wire x1="-2.9" y1="-3.295" x2="-4.095" y2="-3.295" width="0.3" layer="1"/>
-<wire x1="-4.095" y1="-3.295" x2="-4.6" y2="-3.8" width="0.3" layer="1"/>
+<wire x1="10.325" y1="-5.325" x2="10.325" y2="-7.23" width="0.3" layer="1"/>
+<wire x1="10.325" y1="-7.23" x2="10.425" y2="-7.33" width="0.3" layer="1"/>
 </signal>
 <signal name="VDC" class="1">
 <contactref element="C9" pad="2"/>
@@ -11161,6 +11140,7 @@
 <wire x1="-4.975" y1="-11.825" x2="-2.025" y2="-11.825" width="0.5" layer="1"/>
 <wire x1="-0.6" y1="-10.4" x2="2.525" y2="-10.4" width="0.5" layer="1"/>
 <wire x1="2.525" y1="-10.4" x2="2.625" y2="-10.3" width="0.5" layer="1"/>
+<wire x1="2.625" y1="-10.3" x2="2.625" y2="-9.79" width="0.5" layer="1"/>
 <wire x1="-2.025" y1="-11.825" x2="-0.6" y2="-10.4" width="0.5" layer="1"/>
 <wire x1="2.625" y1="-9.79" x2="2.625" y2="-10.3" width="0.5" layer="1"/>
 <wire x1="7.1" y1="-11.2" x2="6.65" y2="-11.65" width="0.5" layer="1"/>
@@ -11168,11 +11148,11 @@
 <wire x1="3.05" y1="-5.825" x2="1.65" y2="-5.825" width="0.5" layer="1"/>
 <wire x1="2.775" y1="-4.575" x2="2.775" y2="-5.825" width="0.5" layer="1"/>
 <wire x1="2.775" y1="-5.825" x2="4.45" y2="-5.825" width="0.5" layer="1"/>
-<wire x1="6.35" y1="-7.025" x2="6.35" y2="-8.14675625" width="0.5" layer="1"/>
+<wire x1="6.35" y1="-6.425" x2="6.35" y2="-8.14675625" width="0.5" layer="1"/>
 <wire x1="6.35" y1="-8.14675625" x2="7.1" y2="-8.89675625" width="0.5" layer="1"/>
-<wire x1="5.15" y1="-5.825" x2="6.35" y2="-7.025" width="0.5" layer="1"/>
+<wire x1="5.75" y1="-5.825" x2="6.35" y2="-6.425" width="0.5" layer="1"/>
 <wire x1="7.1" y1="-8.89675625" x2="7.1" y2="-11.2" width="0.5" layer="1"/>
-<wire x1="4.45" y1="-5.825" x2="5.15" y2="-5.825" width="0.5" layer="1"/>
+<wire x1="4.45" y1="-5.825" x2="5.75" y2="-5.825" width="0.5" layer="1"/>
 <wire x1="2.625" y1="-10.625" x2="2.625" y2="-10.3" width="0.5" layer="1"/>
 <wire x1="6.65" y1="-11.65" x2="3.65" y2="-11.65" width="0.5" layer="1"/>
 <wire x1="3.65" y1="-11.65" x2="2.625" y2="-10.625" width="0.5" layer="1"/>
@@ -11273,8 +11253,8 @@
 <vertex x="-12.45" y="2.1"/>
 <vertex x="-3.1" y="2.1"/>
 <vertex x="-3.1" y="-1"/>
-<vertex x="-0.275" y="-1"/>
-<vertex x="-0.275" y="-0.2"/>
+<vertex x="-0.175" y="-1"/>
+<vertex x="-0.175" y="-0.2"/>
 <vertex x="6" y="-0.2"/>
 <vertex x="6" y="-1"/>
 <vertex x="12.45" y="-1"/>
@@ -11328,12 +11308,12 @@
 <via x="-1.575" y="3.55" extent="1-16" drill="0.3" diameter="0.6"/>
 <via x="-1" y="3.55" extent="1-16" drill="0.3" diameter="0.6"/>
 <via x="-0.4" y="3.55" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-2.875" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-2.275" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-1.675" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-1.075" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-2.775" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-2.175" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-1.575" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-0.975" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
 <via x="-3.375" y="3.55" extent="1-16" drill="0.3" diameter="0.6"/>
-<via x="-0.475" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="-0.375" y="-0.8" extent="1-16" drill="0.3" diameter="0.6"/>
 <polygon width="0.2" layer="1" thermals="no" rank="2">
 <vertex x="11.425" y="-0.5"/>
 <vertex x="11.425" y="4.6"/>
@@ -11367,13 +11347,14 @@
 <vertex x="11.425" y="-0.025"/>
 </polygon>
 <contactref element="C5" pad="2"/>
+<wire x1="-9.8" y1="18" x2="-9.8" y2="17.425" width="0.2" layer="1"/>
 <wire x1="-9.675" y1="15.075" x2="-9.175" y2="15.075" width="0.2" layer="1"/>
 <wire x1="-9.175" y1="15.075" x2="-9.025" y2="15.225" width="0.2" layer="1"/>
 <wire x1="-9.025" y1="15.225" x2="-9.025" y2="16.15" width="0.2" layer="1"/>
 <wire x1="-9.675" y1="16.8" x2="-10.15" y2="16.8" width="0.2" layer="1"/>
 <wire x1="-9.025" y1="16.15" x2="-9.675" y2="16.8" width="0.2" layer="1"/>
 <wire x1="-10.15" y1="16.8" x2="-9.8" y2="16.8" width="0.2" layer="1"/>
-<wire x1="-9.8" y1="16.8" x2="-9.8" y2="18" width="0.2" layer="1"/>
+<wire x1="-9.8" y1="16.8" x2="-9.8" y2="17.425" width="0.2" layer="1"/>
 <contactref element="J1" pad="P$2"/>
 <polygon width="0.15" layer="16" rank="3">
 <vertex x="-12.45" y="18.65"/>
@@ -11483,6 +11464,9 @@
 </signal>
 <signal name="USB_VBUS1">
 </signal>
+<signal name="N$2">
+<contactref element="IC3" pad="8"/>
+</signal>
 <signal name="N$4">
 <contactref element="LED3" pad="G"/>
 <contactref element="LED4" pad="G"/>
@@ -11513,194 +11497,32 @@
 <approved hash="21,19,74ae76ac76ac74ae"/>
 <approved hash="19,1,524d51da464445d3"/>
 <approved hash="19,16,1c1c1d0b19071810"/>
+<approved hash="19,16,fb25c3d101c50f21"/>
 <approved hash="3,16,5601e6f9e6b15649"/>
+<approved hash="3,1,5c43aa1dfc300a6e"/>
 <approved hash="6,1,39d605e161419c27"/>
+<approved hash="19,16,d9b1cf90359023b1"/>
+<approved hash="19,16,1f7aba674063e57e"/>
+<approved hash="23,1,a713f163f15fa72f"/>
 <approved hash="23,2,668c52705270668c"/>
 <approved hash="4,1,cfe86d94ed9a4fe6"/>
 <approved hash="4,1,0be2a99e29a58bd9"/>
 <approved hash="4,1,37d4d5a855afb7d3"/>
 <approved hash="4,1,6c313c7e35b8148d"/>
 <approved hash="4,1,3591b4b234b3b590"/>
+<approved hash="4,1,303b908e43a97419"/>
 <approved hash="4,1,62bce1df61dee2bd"/>
 <approved hash="4,1,a6e72cc4acc526e6"/>
 <approved hash="19,16,161c16e102e50005"/>
 <approved hash="19,16,ae8550ee2094f8f1"/>
-<approved hash="19,16,3387491bc553c055"/>
-<approved hash="19,16,d6607b2574023d92"/>
-<approved hash="4,1,2219a83a283ba218"/>
-<approved hash="4,1,7fba2d10ca37a2e0"/>
-<approved hash="4,1,74f8fa1b7a1af4f9"/>
-<approved hash="4,1,73d7aba0252937a1"/>
-<approved hash="4,1,819b0f788f79019a"/>
-<approved hash="4,1,9a5f193c993d1a5e"/>
-<approved hash="4,1,ac23130093012c22"/>
-<approved hash="4,1,b8ab2688a68938aa"/>
-<approved hash="4,1,b16f304cb04d316e"/>
-<approved hash="4,1,4bcccaef4aeecbcd"/>
-<approved hash="4,1,5d08c32b432add09"/>
-<approved hash="4,1,6880d7a357a2e881"/>
-<approved hash="4,1,2ec12e826cf66cb5"/>
-<approved hash="4,1,c8e2469ee8405d55"/>
-<approved hash="4,1,7f8b9c4776f49120"/>
-<approved hash="4,1,2574b3ebc2015b66"/>
-<approved hash="4,1,e60d4f58cf64a459"/>
-<approved hash="4,1,58c9f7984bbd259d"/>
-<approved hash="4,1,c3414d58c97c8115"/>
-<approved hash="4,1,378237b63fd63fe2"/>
-<approved hash="4,1,cb29b35f5729e5a0"/>
-<approved hash="4,1,f514ae988257e3d9"/>
-<approved hash="4,1,1ea19dc21dc39ea0"/>
-<approved hash="4,1,3c55a2762277bc54"/>
-<approved hash="4,1,8aca70a9f0a80acb"/>
-<approved hash="4,1,f0067ee5fee47007"/>
-<approved hash="4,1,e6426521e5206643"/>
-<approved hash="4,1,ec7e535dd35c6c7f"/>
-<approved hash="4,1,d3ba5999d99853bb"/>
-<approved hash="4,1,d9f647d5c7d459f7"/>
-<approved hash="4,1,cf324e11ce104f33"/>
-<approved hash="4,1,28dd97fe17ffa8dc"/>
-<approved hash="4,1,05658b860b878564"/>
-<approved hash="4,1,a8260a5a8a61281d"/>
-<approved hash="4,1,d42c3650b657542b"/>
-<approved hash="4,1,6c19ce654e6bec17"/>
-<approved hash="4,1,83f6218aa19003ec"/>
-<approved hash="4,2,d51e1d1f9f1f571e"/>
-<approved hash="4,2,0db9efc96dce8fbe"/>
-<approved hash="4,2,d2777007f23c504c"/>
-<approved hash="4,2,ee410c318e366c46"/>
-<approved hash="4,2,167d940d16039473"/>
-<approved hash="4,2,d9865bf6d9ec5b9c"/>
-<approved hash="4,2,958c17fc95f21782"/>
-<approved hash="4,2,71b3d3c351f8f388"/>
-<approved hash="4,2,e2622a63a8636062"/>
-<approved hash="4,2,55e513e30c9ceb8a"/>
-<approved hash="4,2,f7423a43b8437542"/>
-<approved hash="4,2,8ad5a4be0d9f89f6"/>
-<approved hash="4,2,03c1cec04cc081c1"/>
-<approved hash="4,2,1805d9645b649a05"/>
-<approved hash="4,2,2e79d3585158ac79"/>
-<approved hash="4,2,249dec9c6e9ca69d"/>
-<approved hash="4,2,3ad1e6d064d0b8d1"/>
-<approved hash="4,2,3315f0347234b115"/>
-<approved hash="4,2,c9b60a9788974bb6"/>
-<approved hash="4,2,df52035381535d52"/>
-<approved hash="4,2,eada17fb95fb68da"/>
-<approved hash="4,2,e0e62187a38762e6"/>
-<approved hash="4,2,da2af441f7607309"/>
-<approved hash="4,2,3c5e46e947596135"/>
-<approved hash="4,2,defa1f9b9d9b5cfa"/>
-<approved hash="4,2,fc2e202fa22f7e2e"/>
-<approved hash="4,2,4af1f2f070f0c8f1"/>
-<approved hash="4,2,31bdfcbc7ebcb3bd"/>
-<approved hash="4,2,2619e7786578a419"/>
-<approved hash="4,2,2c25d1045304ae25"/>
-<approved hash="4,2,13e1dbe059e091e1"/>
-<approved hash="4,2,19adc5ac47ac9bad"/>
-<approved hash="4,2,0f49cc684e688d49"/>
-<approved hash="4,2,f5ea36cbb4cb77ea"/>
-<approved hash="4,2,e88615a797a76a86"/>
-<approved hash="4,2,c53e083f8a3f473e"/>
-<approved hash="4,2,a6a93a2e652fe620"/>
-<approved hash="4,15,f7423a43b8437542"/>
-<approved hash="4,15,8ad5a4be0d9f89f6"/>
-<approved hash="4,15,03c1cec04cc081c1"/>
-<approved hash="4,15,1805d9645b649a05"/>
-<approved hash="4,15,2e79d3585158ac79"/>
-<approved hash="4,15,249dec9c6e9ca69d"/>
-<approved hash="4,15,3ad1e6d064d0b8d1"/>
-<approved hash="4,15,3315f0347234b115"/>
-<approved hash="4,15,c9b60a9788974bb6"/>
-<approved hash="4,15,df52035381535d52"/>
-<approved hash="4,15,eada17fb95fb68da"/>
-<approved hash="4,15,e0e62187a38762e6"/>
-<approved hash="4,15,da2af441f7607309"/>
-<approved hash="4,15,3c5e46e947596135"/>
-<approved hash="4,15,defa1f9b9d9b5cfa"/>
-<approved hash="4,15,fc2e202fa22f7e2e"/>
-<approved hash="4,15,4af1f2f070f0c8f1"/>
-<approved hash="4,15,31bdfcbc7ebcb3bd"/>
-<approved hash="4,15,2619e7786578a419"/>
-<approved hash="4,15,2c25d1045304ae25"/>
-<approved hash="4,15,13e1dbe059e091e1"/>
-<approved hash="4,15,19adc5ac47ac9bad"/>
-<approved hash="4,15,0f49cc684e688d49"/>
-<approved hash="4,15,f5ea36cbb4cb77ea"/>
-<approved hash="4,15,e88615a797a76a86"/>
-<approved hash="4,15,c53e083f8a3f473e"/>
-<approved hash="4,15,96429621d455d436"/>
-<approved hash="4,15,337a4edb67b48186"/>
-<approved hash="4,15,75d4410b4168718f"/>
-<approved hash="4,15,9d39382f89d4eeb2"/>
-<approved hash="4,15,d51e1d1f9f1f571e"/>
-<approved hash="4,15,0db9efc96dce8fbe"/>
-<approved hash="4,15,d2777007f23c504c"/>
-<approved hash="4,15,ee410c318e366c46"/>
-<approved hash="4,15,167d940d16039473"/>
-<approved hash="4,15,d9865bf6d9ec5b9c"/>
-<approved hash="4,15,958c17fc95f21782"/>
-<approved hash="4,15,71b3d3c351f8f388"/>
-<approved hash="4,15,94d02c18bf5a75e8"/>
-<approved hash="4,15,73c22384b5b99481"/>
-<approved hash="4,15,e2622a63a8636062"/>
-<approved hash="4,15,55e513e30c9ceb8a"/>
-<approved hash="4,16,5744dd675d66d745"/>
-<approved hash="4,16,37d4d5a855afb7d3"/>
-<approved hash="4,16,a8260a5a8a61281d"/>
-<approved hash="4,16,d42c3650b657542b"/>
-<approved hash="4,16,6c19ce654e6bec17"/>
-<approved hash="4,16,83f6218aa19003ec"/>
-<approved hash="4,16,cfe86d94ed9a4fe6"/>
-<approved hash="4,16,0be2a99e29a58bd9"/>
-<approved hash="4,16,8ffce789bdb9acb7"/>
-<approved hash="4,16,2219a83a283ba218"/>
-<approved hash="4,16,7fba2d10ca37a2e0"/>
-<approved hash="4,16,74f8fa1b7a1af4f9"/>
-<approved hash="4,16,73d7aba0252937a1"/>
-<approved hash="4,16,819b0f788f79019a"/>
-<approved hash="4,16,9a5f193c993d1a5e"/>
-<approved hash="4,16,ac23130093012c22"/>
-<approved hash="4,16,a6e72cc4acc526e6"/>
-<approved hash="4,16,b8ab2688a68938aa"/>
-<approved hash="4,16,b16f304cb04d316e"/>
-<approved hash="4,16,4bcccaef4aeecbcd"/>
-<approved hash="4,16,5d08c32b432add09"/>
-<approved hash="4,16,6880d7a357a2e881"/>
-<approved hash="4,16,62bce1df61dee2bd"/>
-<approved hash="4,16,301eb798c8bc8d4a"/>
-<approved hash="4,16,cb29b35f5729e5a0"/>
-<approved hash="4,16,f514ae988257e3d9"/>
-<approved hash="4,16,1ea19dc21dc39ea0"/>
-<approved hash="4,16,3c55a2762277bc54"/>
-<approved hash="4,16,8aca70a9f0a80acb"/>
-<approved hash="4,16,f0067ee5fee47007"/>
-<approved hash="4,16,e6426521e5206643"/>
-<approved hash="4,16,ec7e535dd35c6c7f"/>
-<approved hash="4,16,d3ba5999d99853bb"/>
-<approved hash="4,16,d9f647d5c7d459f7"/>
-<approved hash="4,16,cf324e11ce104f33"/>
-<approved hash="4,16,3591b4b234b3b590"/>
-<approved hash="4,16,28dd97fe17ffa8dc"/>
-<approved hash="4,16,05658b860b878564"/>
-<approved hash="4,16,5d3722cd7de026d8"/>
-<approved hash="4,16,db41de020f76f8eb"/>
-<approved hash="4,16,bd1d246a7f63fd94"/>
-<approved hash="4,16,9fd9031e5a1fdf50"/>
-<approved hash="4,16,13059b76e0fdd8e2"/>
-<approved hash="4,16,8d54c88c687929a1"/>
-<approved hash="4,16,89a519c243dbc92c"/>
-<approved hash="4,16,fede16cae746ec47"/>
-<approved hash="4,16,8cdc8ff17c387525"/>
-<approved hash="4,16,d07530126aeb90fc"/>
-<approved hash="4,16,960d0d5a5453d684"/>
-<approved hash="4,16,fb6d7a14de93446a"/>
-<approved hash="4,16,56ba570a697468c4"/>
-<approved hash="4,16,30bcb47d10fab2b1"/>
-<approved hash="4,16,c6c54eacea2b78d2"/>
-<approved hash="4,1,5744dd675d66d745"/>
 </errors>
 </board>
 </drawing>
 <compatibility>
+<note version="6.3" minversion="6.2.2" severity="warning">
+Since Version 6.2.2 text objects can contain more than one line,
+which will not be processed correctly with this version.
+</note>
 <note version="8.2" severity="warning">
 Since Version 8.2, EAGLE supports online libraries. The ids
 of those online libraries will not be understood (or retained)

--- a/bloxa.sch
+++ b/bloxa.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.6.1">
+<eagle version="9.3.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -67,7 +67,6 @@
 <layer number="57" name="tCAD" color="12" fill="1" visible="no" active="no"/>
 <layer number="58" name="bCAD" color="9" fill="1" visible="no" active="no"/>
 <layer number="59" name="Invisible" color="7" fill="1" visible="no" active="no"/>
-<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
 <layer number="61" name="stand" color="7" fill="1" visible="no" active="no"/>
 <layer number="88" name="SimResults" color="9" fill="1" visible="yes" active="yes"/>
 <layer number="89" name="SimProbes" color="9" fill="1" visible="yes" active="yes"/>
@@ -100,8 +99,6 @@
 <layer number="116" name="Patch_BOT" color="9" fill="4" visible="yes" active="yes"/>
 <layer number="117" name="bMeasures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="118" name="Rect_Pads" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="119" name="KAP_TEKEN" color="7" fill="1" visible="no" active="no"/>
-<layer number="120" name="KAP_MAAT1" color="7" fill="1" visible="no" active="no"/>
 <layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="122" name="_bsilk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
@@ -110,31 +107,18 @@
 <layer number="126" name="_bnames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="127" name="_tvalues" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="128" name="_bvalues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="129" name="top_silk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="130" name="bLogo" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="133" name="bottom_silk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="134" name="silk_top" color="7" fill="1" visible="no" active="yes"/>
-<layer number="135" name="silk_bottom" color="7" fill="1" visible="no" active="yes"/>
-<layer number="136" name="silktop" color="7" fill="1" visible="no" active="yes"/>
-<layer number="137" name="silkbottom" color="7" fill="1" visible="no" active="yes"/>
-<layer number="138" name="EEE" color="7" fill="1" visible="no" active="yes"/>
-<layer number="139" name="_tKeepout" color="7" fill="1" visible="no" active="yes"/>
-<layer number="141" name="ASSEMBLY_TOP" color="7" fill="1" visible="no" active="yes"/>
-<layer number="143" name="PLACE_BOUND_TOP" color="7" fill="1" visible="no" active="yes"/>
 <layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="145" name="DrillLegend_01-16" color="2" fill="9" visible="yes" active="yes"/>
 <layer number="146" name="DrillLegend_01-20" color="3" fill="9" visible="yes" active="yes"/>
-<layer number="147" name="PIN_NUMBER" color="7" fill="1" visible="no" active="yes"/>
 <layer number="150" name="Notes" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="151" name="HeatSink" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="152" name="_bDocu" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="153" name="FabDoc1" color="6" fill="1" visible="no" active="no"/>
 <layer number="154" name="FabDoc2" color="2" fill="1" visible="no" active="no"/>
 <layer number="155" name="FabDoc3" color="7" fill="15" visible="no" active="no"/>
-<layer number="166" name="AntennaArea" color="7" fill="1" visible="no" active="yes"/>
-<layer number="168" name="4mmHeightArea" color="7" fill="1" visible="no" active="yes"/>
 <layer number="199" name="Contour" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="200" name="200bmp" color="1" fill="10" visible="yes" active="yes"/>
 <layer number="201" name="201bmp" color="2" fill="10" visible="yes" active="yes"/>
@@ -210,25 +194,6 @@
 <text x="343.916" y="4.953" size="2.54" layer="94">Sheet:</text>
 <frame x1="0" y1="0" x2="387.35" y2="260.35" columns="8" rows="5" layer="94"/>
 </symbol>
-<symbol name="A5L-LOC" urn="urn:adsk.eagle:symbol:13879/1" library_version="1">
-<wire x1="85.09" y1="3.81" x2="85.09" y2="24.13" width="0.1016" layer="94"/>
-<wire x1="85.09" y1="24.13" x2="139.065" y2="24.13" width="0.1016" layer="94"/>
-<wire x1="139.065" y1="24.13" x2="180.34" y2="24.13" width="0.1016" layer="94"/>
-<wire x1="170.18" y1="3.81" x2="170.18" y2="8.89" width="0.1016" layer="94"/>
-<wire x1="170.18" y1="8.89" x2="180.34" y2="8.89" width="0.1016" layer="94"/>
-<wire x1="170.18" y1="8.89" x2="139.065" y2="8.89" width="0.1016" layer="94"/>
-<wire x1="139.065" y1="8.89" x2="139.065" y2="3.81" width="0.1016" layer="94"/>
-<wire x1="139.065" y1="8.89" x2="139.065" y2="13.97" width="0.1016" layer="94"/>
-<wire x1="139.065" y1="13.97" x2="180.34" y2="13.97" width="0.1016" layer="94"/>
-<wire x1="139.065" y1="13.97" x2="139.065" y2="19.05" width="0.1016" layer="94"/>
-<wire x1="139.065" y1="19.05" x2="180.34" y2="19.05" width="0.1016" layer="94"/>
-<wire x1="139.065" y1="19.05" x2="139.065" y2="24.13" width="0.1016" layer="94"/>
-<text x="140.97" y="15.24" size="2.54" layer="94">&gt;DRAWING_NAME</text>
-<text x="140.97" y="10.16" size="2.286" layer="94">&gt;LAST_DATE_TIME</text>
-<text x="154.305" y="5.08" size="2.54" layer="94">&gt;SHEET</text>
-<text x="140.716" y="4.953" size="2.54" layer="94">Sheet:</text>
-<frame x1="0" y1="0" x2="184.15" y2="133.35" columns="4" rows="4" layer="94"/>
-</symbol>
 </symbols>
 <devicesets>
 <deviceset name="A3L-LOC" urn="urn:adsk.eagle:component:13942/1" prefix="FRAME" uservalue="yes" library_version="1">
@@ -236,19 +201,6 @@
 DIN A3, landscape with location and doc. field</description>
 <gates>
 <gate name="G$1" symbol="A3L-LOC" x="0" y="0"/>
-</gates>
-<devices>
-<device name="">
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="A5L-LOC" urn="urn:adsk.eagle:component:13933/1" prefix="FRAME" uservalue="yes" library_version="1">
-<description>A5L LOC</description>
-<gates>
-<gate name="G$1" symbol="A5L-LOC" x="0" y="0"/>
 </gates>
 <devices>
 <device name="">
@@ -917,7 +869,7 @@ DIN A3, landscape with location and doc. field</description>
 <smd name="P$1" x="0" y="0" dx="1.5" dy="1.5" layer="1" roundness="100"/>
 <circle x="0" y="0" radius="0.9" width="0.1" layer="21"/>
 </package>
-<package name="HOLE_1.5" urn="urn:adsk.eagle:footprint:3332367/3" library_version="21" library_locally_modified="yes">
+<package name="HOLE_1.5" urn="urn:adsk.eagle:footprint:3332367/2" locally_modified="yes" library_version="8" library_locally_modified="yes">
 <pad name="P$1" x="0" y="0" drill="1.5" diameter="2.35"/>
 <text x="0" y="2.54" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
@@ -1027,163 +979,16 @@ DIN A3, landscape with location and doc. field</description>
 <pad name="P$1" x="0" y="0" drill="3"/>
 <text x="0" y="3.06" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
-<package name="HOLE_0.6" urn="urn:adsk.eagle:footprint:6513717/2" library_version="21" library_locally_modified="yes">
+<package name="HOLE_0.6" urn="urn:adsk.eagle:footprint:6513717/1" locally_modified="yes" library_version="8" library_locally_modified="yes">
 <pad name="P$1" x="0" y="0" drill="0.6" shape="square"/>
 </package>
-<package name="SMD_1X1,5" urn="urn:adsk.eagle:footprint:7879125/1" library_version="21" library_locally_modified="yes">
-<smd name="P$1" x="0" y="0" dx="1" dy="1.5" layer="1" roundness="25" rot="R180"/>
-</package>
-<package name="HOLE_1_SQUARE" urn="urn:adsk.eagle:footprint:3188698/4" library_version="21" library_locally_modified="yes">
+<package name="HOLE_1" urn="urn:adsk.eagle:footprint:3188698/2" locally_modified="yes" library_version="8" library_locally_modified="yes">
 <pad name="P$1" x="0" y="0" drill="0.8" diameter="1.4" shape="square"/>
 <text x="1" y="0" size="1.27" layer="25" font="vector" ratio="15" align="center-left">&gt;NAME</text>
 <circle x="0" y="0" radius="0.3" width="0.4" layer="21"/>
 </package>
-<package name="2MM_BULLET" urn="urn:adsk.eagle:footprint:7879124/1" library_version="21" library_locally_modified="yes">
-<pad name="P$1" x="0" y="0" drill="2.1" shape="square"/>
-<wire x1="-1.8" y1="1.6" x2="-1.8" y2="1.8" width="0.127" layer="21"/>
-<wire x1="-1.8" y1="1.8" x2="1.8" y2="1.8" width="0.127" layer="21"/>
-<wire x1="1.8" y1="1.8" x2="1.8" y2="-1.8" width="0.127" layer="21"/>
-<wire x1="1.8" y1="-1.8" x2="-1.5" y2="-1.8" width="0.127" layer="21"/>
-<wire x1="-1.5" y1="-1.8" x2="-1.8" y2="-1.8" width="0.127" layer="21"/>
-<wire x1="-1.8" y1="-1.8" x2="-1.8" y2="1.6" width="0.127" layer="21"/>
-</package>
-<package name="HOLE_1.7" urn="urn:adsk.eagle:footprint:8242903/1" library_version="21" library_locally_modified="yes">
-<pad name="P$1" x="0" y="0" drill="1.7" diameter="2.35"/>
-<text x="0" y="2" size="1" layer="21" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="HOLE_1_OCTO" urn="urn:adsk.eagle:footprint:8242902/1" library_version="21" library_locally_modified="yes">
-<pad name="P$1" x="0" y="0" drill="0.8" diameter="1.4" shape="octagon"/>
-<text x="1" y="0" size="1.27" layer="25" font="vector" ratio="15" align="center-left">&gt;NAME</text>
-<circle x="0" y="0" radius="0.3" width="0.4" layer="21"/>
-</package>
-<package name="HOLE_1_ROUND" urn="urn:adsk.eagle:footprint:11388395/1" library_version="21" library_locally_modified="yes">
-<pad name="P$1" x="0" y="0" drill="0.8" diameter="1.4"/>
-<text x="1" y="0" size="1.27" layer="25" font="vector" ratio="15" align="center-left">&gt;NAME</text>
-<circle x="0" y="0" radius="0.3" width="0.4" layer="21"/>
-</package>
-<package name="HOLE_0.5" urn="urn:adsk.eagle:footprint:11388397/1" library_version="21" library_locally_modified="yes">
-<pad name="P$1" x="0" y="0" drill="0.5" shape="square"/>
-</package>
-<package name="HOLE_0.8" urn="urn:adsk.eagle:footprint:11388398/1" library_version="21" library_locally_modified="yes">
-<pad name="P$1" x="0" y="0" drill="0.8"/>
-</package>
-<package name="HOLE_4" urn="urn:adsk.eagle:footprint:11388399/1" library_version="21" library_locally_modified="yes">
-<pad name="P$1" x="0" y="0" drill="4"/>
-<text x="0" y="3.06" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="7461095" urn="urn:adsk.eagle:footprint:11388396/1" library_version="21" library_locally_modified="yes">
-<wire x1="-4.5" y1="-4.5" x2="-4.5" y2="4.5" width="0.2" layer="51"/>
-<wire x1="-4.5" y1="4.5" x2="4.5" y2="4.5" width="0.2" layer="51"/>
-<wire x1="4.5" y1="4.5" x2="4.5" y2="-4.5" width="0.2" layer="51"/>
-<wire x1="4.5" y1="-4.5" x2="-4.5" y2="-4.5" width="0.2" layer="51"/>
-<pad name="P$1" x="-1.27" y="1.27" drill="1.6" diameter="2.1"/>
-<pad name="P$2" x="-1.27" y="-1.27" drill="1.6" diameter="2.1"/>
-<pad name="P$3" x="1.27" y="-1.27" drill="1.6" diameter="2.1"/>
-<pad name="P$4" x="1.27" y="1.27" drill="1.6" diameter="2.1"/>
-<pad name="P$5" x="1.27" y="3.81" drill="1.6" diameter="2.1"/>
-<pad name="P$6" x="-1.27" y="3.81" drill="1.6" diameter="2.1"/>
-<pad name="P$7" x="-3.81" y="3.81" drill="1.6" diameter="2.1"/>
-<pad name="P$8" x="-3.81" y="1.27" drill="1.6" diameter="2.1"/>
-<pad name="P$9" x="-3.81" y="-1.27" drill="1.6" diameter="2.1"/>
-<pad name="P$10" x="-3.81" y="-3.81" drill="1.6" diameter="2.1"/>
-<pad name="P$11" x="-1.27" y="-3.81" drill="1.6" diameter="2.1"/>
-<pad name="P$12" x="1.27" y="-3.81" drill="1.6" diameter="2.1"/>
-<pad name="P$13" x="3.81" y="-3.81" drill="1.6" diameter="2.1"/>
-<pad name="P$14" x="3.81" y="-1.27" drill="1.6" diameter="2.1"/>
-<pad name="P$15" x="3.81" y="1.27" drill="1.6" diameter="2.1"/>
-<pad name="P$16" x="3.81" y="3.81" drill="1.6" diameter="2.1"/>
-<text x="0" y="6" size="2" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="74650194R" urn="urn:adsk.eagle:footprint:11388440/1" library_version="21" library_locally_modified="yes">
-<pad name="P$1" x="0" y="0" drill="1.85"/>
-<pad name="P$2" x="-4.435" y="0" drill="1.85"/>
-<pad name="P$3" x="4.435" y="0" drill="1.85"/>
-<pad name="P$4" x="4.435" y="-4.435" drill="1.85"/>
-<pad name="P$5" x="0" y="-4.435" drill="1.85"/>
-<pad name="P$6" x="-4.435" y="-4.435" drill="1.85"/>
-<pad name="P$7" x="-4.435" y="4.435" drill="1.85"/>
-<pad name="P$8" x="0" y="4.435" drill="1.85"/>
-<pad name="P$9" x="4.435" y="4.435" drill="1.85"/>
-<wire x1="-5" y1="5" x2="-5" y2="-5" width="0.2" layer="51"/>
-<wire x1="-5" y1="-5" x2="5" y2="-5" width="0.2" layer="51"/>
-<wire x1="5" y1="-5" x2="5" y2="5" width="0.2" layer="51"/>
-<wire x1="5" y1="5" x2="-5" y2="5" width="0.2" layer="51"/>
-<text x="0" y="7" size="2" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="7461148" urn="urn:adsk.eagle:footprint:11388671/2" library_version="21" library_locally_modified="yes">
-<pad name="P$2" x="-2.54" y="0" drill="1.6" diameter="2.1"/>
-<pad name="P$3" x="-2.54" y="2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$4" x="0" y="2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$5" x="2.54" y="2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$6" x="2.54" y="0" drill="1.6" diameter="2.1"/>
-<pad name="P$7" x="2.54" y="-2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$8" x="0" y="-2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$9" x="-2.54" y="-2.54" drill="1.6" diameter="2.1"/>
-<wire x1="-3.5" y1="-3.5" x2="-3.5" y2="3.5" width="0.1" layer="51"/>
-<wire x1="-3.5" y1="3.5" x2="3.5" y2="3.5" width="0.1" layer="51"/>
-<wire x1="3.5" y1="3.5" x2="3.5" y2="-3.5" width="0.1" layer="51"/>
-<wire x1="3.5" y1="-3.5" x2="-3.5" y2="-3.5" width="0.1" layer="51"/>
-<text x="0" y="4.7" size="2" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="7461094" urn="urn:adsk.eagle:footprint:11388721/1" library_version="21" library_locally_modified="yes">
-<pad name="P$2" x="-2.54" y="0" drill="1.6" diameter="2.1"/>
-<pad name="P$3" x="-2.54" y="2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$4" x="0" y="2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$5" x="2.54" y="2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$6" x="2.54" y="0" drill="1.6" diameter="2.1"/>
-<pad name="P$7" x="2.54" y="-2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$8" x="0" y="-2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$9" x="-2.54" y="-2.54" drill="1.6" diameter="2.1"/>
-<pad name="P$1" x="0" y="0" drill="1.6" diameter="2.1"/>
-<wire x1="-3.5" y1="-3.5" x2="-3.5" y2="3.5" width="0.1" layer="51"/>
-<wire x1="-3.5" y1="3.5" x2="3.5" y2="3.5" width="0.1" layer="51"/>
-<wire x1="3.5" y1="3.5" x2="3.5" y2="-3.5" width="0.1" layer="51"/>
-<wire x1="3.5" y1="-3.5" x2="-3.5" y2="-3.5" width="0.1" layer="51"/>
-<text x="0" y="4.7" size="2" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="2X1.5" urn="urn:adsk.eagle:footprint:11682467/1" library_version="21" library_locally_modified="yes">
-<smd name="P$1" x="0" y="0" dx="2" dy="1.5" layer="1" roundness="50"/>
-<wire x1="0.75" y1="-0.9" x2="-0.75" y2="-0.9" width="0.127" layer="51"/>
-<wire x1="-0.75" y1="-0.9" x2="-1.15" y2="-0.5" width="0.127" layer="51" curve="-90"/>
-<wire x1="-1.15" y1="-0.5" x2="-1.15" y2="0.5" width="0.127" layer="51"/>
-<wire x1="-1.15" y1="0.5" x2="-0.75" y2="0.9" width="0.127" layer="51" curve="-90"/>
-<wire x1="-0.75" y1="0.9" x2="0.75" y2="0.9" width="0.127" layer="51"/>
-<wire x1="0.75" y1="0.9" x2="1.15" y2="0.5" width="0.127" layer="51" curve="-90"/>
-<wire x1="1.15" y1="0.5" x2="1.15" y2="-0.5" width="0.127" layer="51"/>
-<wire x1="1.15" y1="-0.5" x2="0.75" y2="-0.9" width="0.127" layer="51" curve="-90"/>
-</package>
-<package name="HOLE_1.77" urn="urn:adsk.eagle:footprint:15477725/1" library_version="21" library_locally_modified="yes">
-<pad name="P$1" x="0" y="0" drill="1.77" diameter="2.35"/>
-<text x="0" y="2" size="1" layer="21" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="1.2X1.2" urn="urn:adsk.eagle:footprint:15477727/1" locally_modified="yes" library_version="21" library_locally_modified="yes">
-<smd name="P$1" x="0" y="0" dx="1.2" dy="1.2" layer="1" roundness="100"/>
-<circle x="0" y="0" radius="0.548290625" width="0.1" layer="51"/>
-</package>
-<package name="1.5X1.5" urn="urn:adsk.eagle:footprint:15477726/1" library_version="21" library_locally_modified="yes">
-<smd name="P$1" x="0" y="0" dx="1.5" dy="1.5" layer="1" roundness="100"/>
-</package>
-<package name="1X1" urn="urn:adsk.eagle:footprint:15477728/1" library_version="21" library_locally_modified="yes">
-<smd name="P$1" x="0" y="0" dx="1" dy="1" layer="1" roundness="100"/>
-</package>
-<package name="8199" urn="urn:adsk.eagle:footprint:15636605/1" library_version="21" library_locally_modified="yes">
-<description>https://www.keyelco.com/product.cfm/30-Amp-Screw-Terminals/8199/product_id/1550</description>
-<pad name="P$1" x="0" y="3.5" drill="2"/>
-<pad name="P$2" x="0" y="-3.5" drill="2"/>
-<pad name="P$3" x="-5" y="3.5" drill="2"/>
-<pad name="P$4" x="-5" y="-3.5" drill="2"/>
-<pad name="P$5" x="5" y="3.5" drill="2"/>
-<pad name="P$6" x="5" y="-3.5" drill="2"/>
-<wire x1="-6.7" y1="5.2" x2="6.7" y2="5.2" width="0.1" layer="21"/>
-<wire x1="6.7" y1="5.2" x2="6.7" y2="-5.2" width="0.1" layer="21"/>
-<wire x1="6.7" y1="-5.2" x2="-6.7" y2="-5.2" width="0.1" layer="21"/>
-<wire x1="-6.7" y1="-5.2" x2="-6.7" y2="5.2" width="0.1" layer="21"/>
-<text x="0" y="0" size="2" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="R75-3X" urn="urn:adsk.eagle:footprint:6366932/1" library_version="21" library_locally_modified="yes">
-<pad name="1" x="0" y="0" drill="1.1"/>
-<text x="0" y="-1.6" size="0.7" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<circle x="0" y="0" radius="1" width="0.1" layer="25"/>
+<package name="SMD_1X1,5" library_version="8" library_locally_modified="yes">
+<smd name="P$1" x="0" y="0" dx="1" dy="1.5" layer="1" roundness="25" rot="R180"/>
 </package>
 </packages>
 <packages3d>
@@ -1212,7 +1017,7 @@ DIN A3, landscape with location and doc. field</description>
 <packageinstance name="2х2"/>
 </packageinstances>
 </package3d>
-<package3d name="HOLE_1.5" urn="urn:adsk.eagle:package:3332368/3" type="box" library_version="21" library_locally_modified="yes">
+<package3d name="HOLE_1.5" urn="urn:adsk.eagle:package:3332368/2" locally_modified="yes" type="box" library_version="8" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="HOLE_1.5"/>
 </packageinstances>
@@ -1279,110 +1084,14 @@ DIN A3, landscape with location and doc. field</description>
 <packageinstance name="HOLE_3"/>
 </packageinstances>
 </package3d>
-<package3d name="HOLE_0.6" urn="urn:adsk.eagle:package:6513718/2" type="box" library_version="21" library_locally_modified="yes">
+<package3d name="HOLE_0.6" urn="urn:adsk.eagle:package:6513718/1" locally_modified="yes" type="box" library_version="8" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="HOLE_0.6"/>
 </packageinstances>
 </package3d>
-<package3d name="SMD_1X1,5" urn="urn:adsk.eagle:package:7879127/1" type="box" library_version="21" library_locally_modified="yes">
+<package3d name="HOLE_1" urn="urn:adsk.eagle:package:3188705/3" locally_modified="yes" type="box" library_version="8" library_locally_modified="yes">
 <packageinstances>
-<packageinstance name="SMD_1X1,5"/>
-</packageinstances>
-</package3d>
-<package3d name="HOLE_1" urn="urn:adsk.eagle:package:3188705/5" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="HOLE_1_SQUARE"/>
-</packageinstances>
-</package3d>
-<package3d name="2MM_BULLET" urn="urn:adsk.eagle:package:7879126/2" type="model" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="2MM_BULLET"/>
-</packageinstances>
-</package3d>
-<package3d name="HOLE_1.7" urn="urn:adsk.eagle:package:8242905/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="HOLE_1.7"/>
-</packageinstances>
-</package3d>
-<package3d name="HOLE_1_OCTO" urn="urn:adsk.eagle:package:8242904/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="HOLE_1_OCTO"/>
-</packageinstances>
-</package3d>
-<package3d name="HOLE_1_ROUND" urn="urn:adsk.eagle:package:11388402/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="HOLE_1_ROUND"/>
-</packageinstances>
-</package3d>
-<package3d name="HOLE_0.5" urn="urn:adsk.eagle:package:11388401/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="HOLE_0.5"/>
-</packageinstances>
-</package3d>
-<package3d name="HOLE_0.8" urn="urn:adsk.eagle:package:11388400/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="HOLE_0.8"/>
-</packageinstances>
-</package3d>
-<package3d name="HOLE_4" urn="urn:adsk.eagle:package:11388404/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="HOLE_4"/>
-</packageinstances>
-</package3d>
-<package3d name="7461095" urn="urn:adsk.eagle:package:11388403/2" type="model" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="7461095"/>
-</packageinstances>
-</package3d>
-<package3d name="74650194R" urn="urn:adsk.eagle:package:11388441/2" type="model" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="74650194R"/>
-</packageinstances>
-</package3d>
-<package3d name="7461148" urn="urn:adsk.eagle:package:11388672/3" type="model" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="7461148"/>
-</packageinstances>
-</package3d>
-<package3d name="7461094" urn="urn:adsk.eagle:package:11388722/2" type="model" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="7461094"/>
-</packageinstances>
-</package3d>
-<package3d name="2X1.5" urn="urn:adsk.eagle:package:11682468/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="2X1.5"/>
-</packageinstances>
-</package3d>
-<package3d name="HOLE_1.77" urn="urn:adsk.eagle:package:15477729/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="HOLE_1.77"/>
-</packageinstances>
-</package3d>
-<package3d name="1.2X1.2" urn="urn:adsk.eagle:package:15477731/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="1.2X1.2"/>
-</packageinstances>
-</package3d>
-<package3d name="1.5X1.5" urn="urn:adsk.eagle:package:15477730/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="1.5X1.5"/>
-</packageinstances>
-</package3d>
-<package3d name="1X1" urn="urn:adsk.eagle:package:15477732/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="1X1"/>
-</packageinstances>
-</package3d>
-<package3d name="8199" urn="urn:adsk.eagle:package:15636606/2" type="model" library_version="21" library_locally_modified="yes">
-<description>https://www.keyelco.com/product.cfm/30-Amp-Screw-Terminals/8199/product_id/1550</description>
-<packageinstances>
-<packageinstance name="8199"/>
-</packageinstances>
-</package3d>
-<package3d name="R75-3X" urn="urn:adsk.eagle:package:6366935/1" type="box" library_version="21" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="R75-3X"/>
+<packageinstance name="HOLE_1"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -1395,7 +1104,7 @@ DIN A3, landscape with location and doc. field</description>
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="PAD" urn="urn:adsk.eagle:component:3188710/19" locally_modified="yes" prefix="PAD" library_version="21" library_locally_modified="yes">
+<deviceset name="PAD" urn="urn:adsk.eagle:component:3188710/8" locally_modified="yes" prefix="PAD" library_version="8" library_locally_modified="yes">
 <gates>
 <gate name="G$1" symbol="PAD" x="-20.32" y="7.62"/>
 </gates>
@@ -1452,12 +1161,12 @@ DIN A3, landscape with location and doc. field</description>
 </technology>
 </technologies>
 </device>
-<device name="-HOLE_1" package="HOLE_1_SQUARE">
+<device name="-HOLE_1" package="HOLE_1">
 <connects>
 <connect gate="G$1" pin="P$1" pad="P$1"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:3188705/5"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:3188705/3"/>
 </package3dinstances>
 <technologies>
 <technology name="">
@@ -1483,7 +1192,7 @@ DIN A3, landscape with location and doc. field</description>
 <connect gate="G$1" pin="P$1" pad="P$1"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:3332368/3"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:3332368/2"/>
 </package3dinstances>
 <technologies>
 <technology name="">
@@ -1652,7 +1361,7 @@ DIN A3, landscape with location and doc. field</description>
 <connect gate="G$1" pin="P$1" pad="P$1"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:6513718/2"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6513718/1"/>
 </package3dinstances>
 <technologies>
 <technology name=""/>
@@ -1662,216 +1371,6 @@ DIN A3, landscape with location and doc. field</description>
 <connects>
 <connect gate="G$1" pin="P$1" pad="P$1"/>
 </connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:7879127/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-2MM_BULLET" package="2MM_BULLET">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:7879126/2"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-HOLE-1.7" package="HOLE_1.7">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:8242905/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-HOLE_1_OCTO" package="HOLE_1_OCTO">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:8242904/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-HOLE-1-ROUND" package="HOLE_1_ROUND">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:11388402/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-HOLE-0.5" package="HOLE_0.5">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:11388401/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-HOLE-0.8" package="HOLE_0.8">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:11388400/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-HOLE_4" package="HOLE_4">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:11388404/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-7461095" package="7461095">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1 P$2 P$3 P$4 P$5 P$6 P$7 P$8 P$9 P$10 P$11 P$12 P$13 P$14 P$15 P$16"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:11388403/2"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-74650194R" package="74650194R">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1 P$2 P$3 P$4 P$5 P$6 P$7 P$8 P$9"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:11388441/2"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-7461148" package="7461148">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$2 P$3 P$4 P$5 P$6 P$7 P$8 P$9"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:11388672/3"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-77461094" package="7461094">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1 P$2 P$3 P$4 P$5 P$6 P$7 P$8 P$9"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:11388722/2"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="CURRENT_RATING" value="130A" constant="no"/>
-<attribute name="DIGIKEY#" value="732-3212-ND" constant="no"/>
-<attribute name="MANF" value="Wurth Electronics Inc" constant="no"/>
-<attribute name="MANF#" value="7461094" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-2X1.5" package="2X1.5">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:11682468/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-HOLE-1.77" package="HOLE_1.77">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:15477729/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-S-1.2" package="1.2X1.2">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:15477731/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-S-1.5" package="1.5X1.5">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:15477730/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-S-1" package="1X1">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:15477732/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-8199" package="8199">
-<connects>
-<connect gate="G$1" pin="P$1" pad="P$1 P$2 P$3 P$4 P$5 P$6"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:15636606/2"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="DIGIKEY#" value="36-8199-ND" constant="no"/>
-<attribute name="MANF" value="Keystone Electronics" constant="no"/>
-<attribute name="MANF#" value="8199" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-R75-3X" package="R75-3X">
-<connects>
-<connect gate="G$1" pin="P$1" pad="1"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:6366935/1"/>
-</package3dinstances>
 <technologies>
 <technology name=""/>
 </technologies>
@@ -2347,33 +1846,6 @@ DIN A3, landscape with location and doc. field</description>
 <rectangle x1="-3.2" y1="-1.5" x2="-2.5" y2="1.5" layer="51"/>
 <rectangle x1="2.5" y1="-1.5" x2="3.2" y2="1.5" layer="51"/>
 </package>
-<package name="R2010-KELVIN" urn="urn:adsk.eagle:footprint:8637301/1" library_version="16">
-<wire x1="3.45" y1="-1.9" x2="3.45" y2="1.9" width="0.15" layer="21"/>
-<wire x1="3.45" y1="1.9" x2="-3.45" y2="1.9" width="0.15" layer="21"/>
-<wire x1="-3.45" y1="1.9" x2="-3.45" y2="-1.9" width="0.15" layer="21"/>
-<wire x1="-3.45" y1="-1.9" x2="3.45" y2="-1.9" width="0.15" layer="21"/>
-<text x="0" y="0" size="1.3" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<text x="0" y="-2.7" size="1.3" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
-<smd name="S1" x="-2.5" y="0" dx="1.5" dy="0.6" layer="1"/>
-<smd name="1" x="-2.5" y="1.2" dx="1.5" dy="1" layer="1"/>
-<smd name="11" x="-2.5" y="-1.2" dx="1.5" dy="1" layer="1"/>
-<smd name="S2" x="2.5" y="0" dx="1.5" dy="0.6" layer="1"/>
-<smd name="2" x="2.5" y="1.2" dx="1.5" dy="1" layer="1"/>
-<smd name="22" x="2.5" y="-1.2" dx="1.5" dy="1" layer="1"/>
-</package>
-<package name="R3920-KELVIN" urn="urn:adsk.eagle:footprint:10874635/1" library_version="16">
-<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<smd name="1" x="-4.15" y="1.85" dx="2.7" dy="2.5" layer="1"/>
-<smd name="2" x="4.15" y="1.85" dx="2.7" dy="2.5" layer="1"/>
-<smd name="11" x="-4.15" y="-1.85" dx="2.7" dy="2.5" layer="1"/>
-<smd name="S1" x="-4.15" y="0" dx="2.7" dy="0.6" layer="1"/>
-<smd name="22" x="4.15" y="-1.85" dx="2.7" dy="2.5" layer="1"/>
-<smd name="S2" x="4.15" y="0" dx="2.7" dy="0.6" layer="1"/>
-<wire x1="-5.7" y1="3.3" x2="-5.7" y2="-3.3" width="0.1" layer="21"/>
-<wire x1="-5.7" y1="-3.3" x2="5.7" y2="-3.3" width="0.1" layer="21"/>
-<wire x1="5.7" y1="-3.3" x2="5.7" y2="3.3" width="0.1" layer="21"/>
-<wire x1="5.7" y1="3.3" x2="-5.7" y2="3.3" width="0.1" layer="21"/>
-</package>
 </packages>
 <packages3d>
 <package3d name="R2512-KELVIN" urn="urn:adsk.eagle:package:3560627/3" type="model" library_version="5" library_locally_modified="yes">
@@ -2389,16 +1861,6 @@ DIN A3, landscape with location and doc. field</description>
 <package3d name="R2512-WIRE-KELVIN" urn="urn:adsk.eagle:package:6401683/2" type="model" library_version="8" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="R2512-WIRE-KELVIN"/>
-</packageinstances>
-</package3d>
-<package3d name="R2010-KELVIN" urn="urn:adsk.eagle:package:8637302/2" type="model" library_version="16">
-<packageinstances>
-<packageinstance name="R2010-KELVIN"/>
-</packageinstances>
-</package3d>
-<package3d name="R3920-KELVIN" urn="urn:adsk.eagle:package:10874636/2" type="model" library_version="16">
-<packageinstances>
-<packageinstance name="R3920-KELVIN"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -2425,7 +1887,7 @@ DIN A3, landscape with location and doc. field</description>
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="CURRENT_SHUNT_KELVIN" urn="urn:adsk.eagle:component:3560628/12" prefix="R" library_version="16">
+<deviceset name="CURRENT_SHUNT_KELVIN" urn="urn:adsk.eagle:component:3560628/7" locally_modified="yes" prefix="R" library_version="9" library_locally_modified="yes">
 <gates>
 <gate name="G$1" symbol="SHUNT_4_TERMINAL" x="2.54" y="2.54"/>
 </gates>
@@ -2476,15 +1938,6 @@ DIN A3, landscape with location and doc. field</description>
 <attribute name="TC" value="±50ppm/°C" constant="no"/>
 <attribute name="TOLERANCE" value="±1%" constant="no"/>
 <attribute name="VALUE" value="5 mOhms" constant="no"/>
-</technology>
-<technology name="-0.010R">
-<attribute name="DIGIKEY#" value="CSNL2512FT10L0CT-ND" constant="no"/>
-<attribute name="MANF" value="Stackpole Electronics Inc" constant="no"/>
-<attribute name="MANF#" value="CSNL2512FT10L0" constant="no"/>
-<attribute name="POWER" value="2W" constant="no"/>
-<attribute name="TC" value="±50ppm/°C" constant="no"/>
-<attribute name="TOLERANCE" value="±1%" constant="no"/>
-<attribute name="VALUE" value="10 mOhms" constant="no"/>
 </technology>
 </technologies>
 </device>
@@ -2541,60 +1994,6 @@ DIN A3, landscape with location and doc. field</description>
 </technology>
 </technologies>
 </device>
-<device name="-2010-KELVIN" package="R2010-KELVIN">
-<connects>
-<connect gate="G$1" pin="1" pad="1 11"/>
-<connect gate="G$1" pin="2" pad="2 22"/>
-<connect gate="G$1" pin="S1" pad="S1"/>
-<connect gate="G$1" pin="S2" pad="S2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:8637302/2"/>
-</package3dinstances>
-<technologies>
-<technology name="-0.001R">
-<attribute name="DIGIKEY#" value="CSNL2010FT1L00TR-ND" constant="no"/>
-<attribute name="MANF" value="Stackpole Electronics Inc." constant="no"/>
-<attribute name="MANF#" value="CSNL2010FT1L00" constant="no"/>
-<attribute name="POWER" value="1.5W" constant="no"/>
-<attribute name="TC" value="±50ppm/°C" constant="no"/>
-<attribute name="TOLERANCE" value="1%" constant="no"/>
-<attribute name="VALUE" value="0.001R" constant="no"/>
-</technology>
-<technology name="-0.005R">
-<attribute name="DIGIKEY#" value="CSNL2010FT5L00CT-ND" constant="no"/>
-<attribute name="MANF" value="Stackpole Electronics Inc." constant="no"/>
-<attribute name="MANF#" value="CSNL2010FT5L00" constant="no"/>
-<attribute name="POWER" value="1.5W" constant="no"/>
-<attribute name="TC" value="±50ppm/°C" constant="no"/>
-<attribute name="TOLERANCE" value="1%" constant="no"/>
-<attribute name="VALUE" value="0.005R" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-3920-KELVIN" package="R3920-KELVIN">
-<connects>
-<connect gate="G$1" pin="1" pad="1 11"/>
-<connect gate="G$1" pin="2" pad="2 22"/>
-<connect gate="G$1" pin="S1" pad="S1"/>
-<connect gate="G$1" pin="S2" pad="S2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:10874636/2"/>
-</package3dinstances>
-<technologies>
-<technology name="-0.001R">
-<attribute name="DIGIKEY#" value="CSS2H-3920R-1L00FTR-ND" constant="no"/>
-<attribute name="MANF" value="Bourns Inc" constant="no"/>
-<attribute name="MANF#" value="CSS2H-3920R-1L00F" constant="no"/>
-<attribute name="PACKAGE" value="3920" constant="no"/>
-<attribute name="POWER" value="8W" constant="no"/>
-<attribute name="TC" value="±50ppm/°C" constant="no"/>
-<attribute name="TOLERANCE" value="1%" constant="no"/>
-<attribute name="VALUE" value="0.001R" constant="no"/>
-</technology>
-</technologies>
-</device>
 </devices>
 </deviceset>
 </devicesets>
@@ -2627,11 +2026,76 @@ DIN A3, landscape with location and doc. field</description>
 <rectangle x1="-1.65" y1="-0.25" x2="-0.75" y2="0.25" layer="51"/>
 <circle x="-1" y="1.6" radius="0.111803125" width="0.1" layer="21"/>
 </package>
+<package name="0805_LED" urn="urn:adsk.eagle:footprint:1040134/1" library_version="1">
+<smd name="A" x="-0.9525" y="0" dx="0.9" dy="1.3" layer="1"/>
+<smd name="C" x="1.0475" y="0" dx="0.9" dy="1.3" layer="1"/>
+<wire x1="-0.9525" y1="0.6" x2="1.0475" y2="0.6" width="0.127" layer="51"/>
+<wire x1="1.0475" y1="0.6" x2="1.0475" y2="-0.6" width="0.127" layer="51"/>
+<wire x1="1.0475" y1="-0.6" x2="-0.9525" y2="-0.6" width="0.127" layer="51"/>
+<wire x1="-0.9525" y1="-0.6" x2="-0.9525" y2="0.6" width="0.127" layer="51"/>
+<wire x1="0.62" y1="0.58" x2="0.62" y2="-0.59" width="0.127" layer="51" style="dashdot"/>
+<text x="-0.9525" y="-0.635" size="0.508" layer="21">&gt;NAME</text>
+</package>
+<package name="0603_LED" urn="urn:adsk.eagle:footprint:1040135/1" library_version="1">
+<smd name="C" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<smd name="A" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<text x="0" y="0.9" size="0.4" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-0.275" y1="0.55" x2="-0.275" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-0.275" y1="-0.55" x2="-0.175" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-0.175" y1="-0.55" x2="-0.175" y2="0.55" width="0.1" layer="21"/>
+<wire x1="-0.175" y1="0.55" x2="-0.275" y2="0.55" width="0.1" layer="21"/>
+<wire x1="-1.2" y1="0.6" x2="1.2" y2="0.6" width="0.1" layer="21"/>
+<wire x1="1.2" y1="0.6" x2="1.2" y2="-0.6" width="0.1" layer="21"/>
+<wire x1="1.2" y1="-0.6" x2="-1.2" y2="-0.6" width="0.1" layer="21"/>
+<wire x1="-1.2" y1="-0.6" x2="-1.2" y2="0.6" width="0.1" layer="21"/>
+</package>
+<package name="0402_LED" urn="urn:adsk.eagle:footprint:1040136/1" library_version="1">
+<smd name="C" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="A" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-0.95" y1="0.5" x2="0.95" y2="0.5" width="0.15" layer="21"/>
+<wire x1="0.95" y1="0.5" x2="0.95" y2="-0.5" width="0.15" layer="21"/>
+<wire x1="0.95" y1="-0.5" x2="-0.95" y2="-0.5" width="0.15" layer="21"/>
+<wire x1="-0.95" y1="-0.5" x2="-0.95" y2="0.5" width="0.15" layer="21"/>
+<wire x1="-0.4" y1="0.5" x2="-0.4" y2="-0.5" width="0.15" layer="51"/>
+</package>
+<package name="LITE_ON_RGB_LED" urn="urn:adsk.eagle:footprint:1040103/1" library_version="1">
+<smd name="R" x="-0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="G" x="0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="+" x="-0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="B" x="0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
+<text x="0" y="1.75" size="0.6" layer="25" font="vector" ratio="15" rot="R180" align="center">&gt;NAME</text>
+<wire x1="-0.95" y1="1.35" x2="0.95" y2="1.35" width="0.1524" layer="21"/>
+<wire x1="0.95" y1="1.35" x2="0.95" y2="-1.35" width="0.1524" layer="21"/>
+<wire x1="0.95" y1="-1.35" x2="-0.95" y2="-1.35" width="0.1524" layer="21"/>
+<wire x1="-0.95" y1="-1.35" x2="-0.95" y2="1.35" width="0.1524" layer="21"/>
+<circle x="-1.25" y="1.25" radius="0.1" width="0.1524" layer="21"/>
+</package>
 </packages>
 <packages3d>
 <package3d name="SOT26" urn="urn:adsk.eagle:package:1040217/3" type="model" library_version="19">
 <packageinstances>
 <packageinstance name="SOT26"/>
+</packageinstances>
+</package3d>
+<package3d name="0805_LED" urn="urn:adsk.eagle:package:1040214/1" type="box" library_version="15" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="0805_LED"/>
+</packageinstances>
+</package3d>
+<package3d name="0603_LED" urn="urn:adsk.eagle:package:1040215/1" type="box" library_version="15" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="0603_LED"/>
+</packageinstances>
+</package3d>
+<package3d name="0402_LED" urn="urn:adsk.eagle:package:1040216/2" type="model" library_version="15" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="0402_LED"/>
+</packageinstances>
+</package3d>
+<package3d name="LITE_ON_RGB_LED" urn="urn:adsk.eagle:package:1040199/2" type="model" library_version="18">
+<packageinstances>
+<packageinstance name="LITE_ON_RGB_LED"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -2649,6 +2113,64 @@ DIN A3, landscape with location and doc. field</description>
 <wire x1="12.7" y1="15.24" x2="0" y2="15.24" width="0.254" layer="94"/>
 <text x="6.35" y="16.51" size="2.54" layer="97" font="vector" ratio="15" align="center">&gt;NAME</text>
 <text x="6.35" y="-1.27" size="1.778" layer="97" font="vector" ratio="15" align="center">TPD3S014</text>
+</symbol>
+<symbol name="LED" urn="urn:adsk.eagle:symbol:1040133/1" library_version="1">
+<wire x1="0" y1="1.27" x2="0" y2="-1.27" width="0.254" layer="94"/>
+<wire x1="0" y1="-1.27" x2="2.54" y2="0" width="0.254" layer="94"/>
+<wire x1="2.54" y1="0" x2="0" y2="1.27" width="0.254" layer="94"/>
+<wire x1="2.54" y1="1.27" x2="2.54" y2="0" width="0.254" layer="94"/>
+<wire x1="2.54" y1="0" x2="2.54" y2="-1.27" width="0.254" layer="94"/>
+<wire x1="2.54" y1="2.54" x2="5.08" y2="5.08" width="0.254" layer="94"/>
+<wire x1="5.08" y1="5.08" x2="3.81" y2="5.08" width="0.254" layer="94"/>
+<wire x1="5.08" y1="3.81" x2="5.08" y2="5.08" width="0.254" layer="94"/>
+<pin name="A" x="-2.54" y="0" visible="off" length="short"/>
+<pin name="C" x="5.08" y="0" visible="off" length="short" rot="R180"/>
+<text x="-2.54" y="1.778" size="1.27" layer="95">&gt;NAME</text>
+</symbol>
+<symbol name="RGB_LED" urn="urn:adsk.eagle:symbol:1040102/1" library_version="1">
+<wire x1="5.08" y1="8.89" x2="5.08" y2="7.62" width="0.254" layer="94"/>
+<wire x1="5.08" y1="7.62" x2="5.08" y2="6.35" width="0.254" layer="94"/>
+<wire x1="5.08" y1="6.35" x2="7.62" y2="7.62" width="0.254" layer="94"/>
+<wire x1="7.62" y1="7.62" x2="5.08" y2="8.89" width="0.254" layer="94"/>
+<wire x1="7.62" y1="8.89" x2="7.62" y2="7.62" width="0.254" layer="94"/>
+<wire x1="7.62" y1="7.62" x2="7.62" y2="6.35" width="0.254" layer="94"/>
+<wire x1="5.08" y1="13.97" x2="5.08" y2="12.7" width="0.254" layer="94"/>
+<wire x1="5.08" y1="12.7" x2="5.08" y2="11.43" width="0.254" layer="94"/>
+<wire x1="5.08" y1="11.43" x2="7.62" y2="12.7" width="0.254" layer="94"/>
+<wire x1="7.62" y1="12.7" x2="5.08" y2="13.97" width="0.254" layer="94"/>
+<wire x1="7.62" y1="13.97" x2="7.62" y2="12.7" width="0.254" layer="94"/>
+<wire x1="7.62" y1="12.7" x2="7.62" y2="11.43" width="0.254" layer="94"/>
+<wire x1="7.62" y1="17.78" x2="10.16" y2="20.32" width="0.254" layer="94"/>
+<wire x1="10.16" y1="20.32" x2="8.89" y2="20.32" width="0.254" layer="94"/>
+<wire x1="10.16" y1="19.05" x2="10.16" y2="20.32" width="0.254" layer="94"/>
+<wire x1="5.08" y1="3.81" x2="5.08" y2="2.54" width="0.254" layer="94"/>
+<wire x1="5.08" y1="2.54" x2="5.08" y2="1.27" width="0.254" layer="94"/>
+<wire x1="5.08" y1="1.27" x2="7.62" y2="2.54" width="0.254" layer="94"/>
+<wire x1="7.62" y1="2.54" x2="5.08" y2="3.81" width="0.254" layer="94"/>
+<wire x1="7.62" y1="3.81" x2="7.62" y2="2.54" width="0.254" layer="94"/>
+<wire x1="7.62" y1="2.54" x2="7.62" y2="1.27" width="0.254" layer="94"/>
+<wire x1="0" y1="15.24" x2="0" y2="7.62" width="0.254" layer="94"/>
+<wire x1="0" y1="7.62" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="10.16" y2="0" width="0.254" layer="94"/>
+<wire x1="5.08" y1="17.78" x2="7.62" y2="20.32" width="0.254" layer="94"/>
+<wire x1="7.62" y1="20.32" x2="6.35" y2="20.32" width="0.254" layer="94"/>
+<wire x1="7.62" y1="19.05" x2="7.62" y2="20.32" width="0.254" layer="94"/>
+<wire x1="10.16" y1="15.24" x2="10.16" y2="0" width="0.254" layer="94"/>
+<wire x1="10.16" y1="15.24" x2="0" y2="15.24" width="0.254" layer="94"/>
+<wire x1="5.08" y1="2.54" x2="2.54" y2="2.54" width="0.254" layer="94"/>
+<wire x1="2.54" y1="2.54" x2="2.54" y2="7.62" width="0.254" layer="94"/>
+<wire x1="2.54" y1="7.62" x2="2.54" y2="12.7" width="0.254" layer="94"/>
+<wire x1="2.54" y1="12.7" x2="5.08" y2="12.7" width="0.254" layer="94"/>
+<wire x1="5.08" y1="7.62" x2="2.54" y2="7.62" width="0.254" layer="94"/>
+<wire x1="2.54" y1="7.62" x2="0" y2="7.62" width="0.254" layer="94"/>
+<pin name="G" x="12.7" y="7.62" visible="off" length="middle" rot="R180"/>
+<pin name="R" x="12.7" y="12.7" visible="off" length="middle" rot="R180"/>
+<pin name="B" x="12.7" y="2.54" visible="off" length="middle" rot="R180"/>
+<pin name="A" x="-2.54" y="7.62" visible="off" length="short"/>
+<text x="5.08" y="16.256" size="1.27" layer="95" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="10.922" y="12.954" size="1.27" layer="97">R</text>
+<text x="10.922" y="7.874" size="1.27" layer="97">G</text>
+<text x="10.922" y="2.794" size="1.27" layer="97">B</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -2674,6 +2196,97 @@ DIN A3, landscape with location and doc. field</description>
 <attribute name="DIGIKEY#" value="296-38835-1-ND" constant="no"/>
 <attribute name="MANF" value="Texas Instruments" constant="no"/>
 <attribute name="MANF#" value="TPD3S014DBVR" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="LED" urn="urn:adsk.eagle:component:1040261/6" prefix="LED" uservalue="yes" library_version="15" library_locally_modified="yes">
+<gates>
+<gate name="G$1" symbol="LED" x="-2.54" y="0"/>
+</gates>
+<devices>
+<device name="-0805" package="0805_LED">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:1040214/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-0603" package="0603_LED">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:1040215/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-0402" package="0402_LED">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:1040216/2"/>
+</package3dinstances>
+<technologies>
+<technology name="-BLUE">
+<attribute name="COLOR" value="BLUE" constant="no"/>
+<attribute name="DIGIKEY#" value="511-1615-1-ND" constant="no"/>
+<attribute name="MANF" value="Rohm Semiconductor" constant="no"/>
+<attribute name="MANF#" value="SMLP12BC7TT86" constant="no"/>
+</technology>
+<technology name="-GREEN">
+<attribute name="COLOR" value="GREEN" constant="no"/>
+<attribute name="DIGIKEY#" value="511-1652-1-ND" constant="no"/>
+<attribute name="MANF" value="Rohm Semiconductor" constant="no"/>
+<attribute name="MANF#" value="SML-P11MTT86" constant="no"/>
+</technology>
+<technology name="-ORANGE">
+<attribute name="COLOR" value="ORANGE" constant="no"/>
+<attribute name="DIGIKEY#" value="511-1651-1-ND" constant="no"/>
+<attribute name="MANF" value="Rohm Semiconductor" constant="no"/>
+<attribute name="MANF#" value="SML-P11DTT86" constant="no"/>
+</technology>
+<technology name="-RED">
+<attribute name="COLOR" value="RED" constant="no"/>
+<attribute name="DIGIKEY#" value="511-1653-1-ND" constant="no"/>
+<attribute name="MANF" value="Rohm Semiconductor" constant="no"/>
+<attribute name="MANF#" value="SML-P11UTT86" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="LTST-C19HE1WT" urn="urn:adsk.eagle:component:1040242/6" prefix="LED" library_version="18">
+<gates>
+<gate name="G$1" symbol="RGB_LED" x="-2.54" y="-7.62"/>
+</gates>
+<devices>
+<device name="" package="LITE_ON_RGB_LED">
+<connects>
+<connect gate="G$1" pin="A" pad="+"/>
+<connect gate="G$1" pin="B" pad="B"/>
+<connect gate="G$1" pin="G" pad="G"/>
+<connect gate="G$1" pin="R" pad="R"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:1040199/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="DIGIKEY#" value="160-2162-1-ND" constant="no"/>
+<attribute name="MANF" value="Lite-On Inc" constant="no"/>
+<attribute name="MANF#" value="LTST-C19HE1WT" constant="no"/>
 </technology>
 </technologies>
 </device>
@@ -2966,18 +2579,6 @@ DIN A3, landscape with location and doc. field</description>
 <circle x="0" y="0" radius="1.5" width="0.127" layer="41"/>
 <smd name="P$1" x="0" y="0" dx="1.016" dy="1.016" layer="1" roundness="100" cream="no"/>
 </package>
-<package name="0606" urn="urn:adsk.eagle:footprint:20072924/1" library_version="83" library_locally_modified="yes">
-<circle x="-1.25" y="1.25" radius="0.1" width="0.1524" layer="21"/>
-<wire x1="-0.95" y1="1.35" x2="0.95" y2="1.35" width="0.1524" layer="21"/>
-<wire x1="0.95" y1="1.35" x2="0.95" y2="-1.35" width="0.1524" layer="21"/>
-<wire x1="0.95" y1="-1.35" x2="-0.95" y2="-1.35" width="0.1524" layer="21"/>
-<wire x1="-0.95" y1="-1.35" x2="-0.95" y2="1.35" width="0.1524" layer="21"/>
-<smd name="+" x="-0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="B" x="0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="G" x="0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="R" x="-0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
-<text x="0" y="1.75" size="0.6" layer="25" font="vector" ratio="15" rot="R180" align="center">&gt;NAME</text>
-</package>
 </packages>
 <packages3d>
 <package3d name="SENSE-0.6" urn="urn:adsk.eagle:package:7365871/1" type="box" library_version="8">
@@ -2999,11 +2600,6 @@ DIN A3, landscape with location and doc. field</description>
 <package3d name="CONNECTION" urn="urn:adsk.eagle:package:7439847/1" type="box" library_version="9">
 <packageinstances>
 <packageinstance name="CONNECTION"/>
-</packageinstances>
-</package3d>
-<package3d name="0606" urn="urn:adsk.eagle:package:20072926/2" type="model" library_version="83" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="0606"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -3033,52 +2629,6 @@ DIN A3, landscape with location and doc. field</description>
 </symbol>
 <symbol name="FIDUCIAL" library_version="9" library_locally_modified="yes">
 <circle x="0" y="0" radius="2.54" width="0.254" layer="94"/>
-</symbol>
-<symbol name="RGB_LED" urn="urn:adsk.eagle:symbol:20072922/2" library_version="83" library_locally_modified="yes">
-<wire x1="5.08" y1="8.89" x2="5.08" y2="7.62" width="0.254" layer="94"/>
-<wire x1="5.08" y1="7.62" x2="5.08" y2="6.35" width="0.254" layer="94"/>
-<wire x1="5.08" y1="6.35" x2="7.62" y2="7.62" width="0.254" layer="94"/>
-<wire x1="7.62" y1="7.62" x2="5.08" y2="8.89" width="0.254" layer="94"/>
-<wire x1="7.62" y1="8.89" x2="7.62" y2="7.62" width="0.254" layer="94"/>
-<wire x1="7.62" y1="7.62" x2="7.62" y2="6.35" width="0.254" layer="94"/>
-<wire x1="5.08" y1="13.97" x2="5.08" y2="12.7" width="0.254" layer="94"/>
-<wire x1="5.08" y1="12.7" x2="5.08" y2="11.43" width="0.254" layer="94"/>
-<wire x1="5.08" y1="11.43" x2="7.62" y2="12.7" width="0.254" layer="94"/>
-<wire x1="7.62" y1="12.7" x2="5.08" y2="13.97" width="0.254" layer="94"/>
-<wire x1="7.62" y1="13.97" x2="7.62" y2="12.7" width="0.254" layer="94"/>
-<wire x1="7.62" y1="12.7" x2="7.62" y2="11.43" width="0.254" layer="94"/>
-<wire x1="5.08" y1="3.81" x2="5.08" y2="2.54" width="0.254" layer="94"/>
-<wire x1="5.08" y1="2.54" x2="5.08" y2="1.27" width="0.254" layer="94"/>
-<wire x1="5.08" y1="1.27" x2="7.62" y2="2.54" width="0.254" layer="94"/>
-<wire x1="7.62" y1="2.54" x2="5.08" y2="3.81" width="0.254" layer="94"/>
-<wire x1="7.62" y1="3.81" x2="7.62" y2="2.54" width="0.254" layer="94"/>
-<wire x1="7.62" y1="2.54" x2="7.62" y2="1.27" width="0.254" layer="94"/>
-<wire x1="0" y1="15.24" x2="0" y2="7.62" width="0.254" layer="94"/>
-<wire x1="0" y1="7.62" x2="0" y2="0" width="0.254" layer="94"/>
-<wire x1="0" y1="0" x2="10.16" y2="0" width="0.254" layer="94"/>
-<wire x1="10.16" y1="15.24" x2="10.16" y2="0" width="0.254" layer="94"/>
-<wire x1="10.16" y1="15.24" x2="0" y2="15.24" width="0.254" layer="94"/>
-<wire x1="5.08" y1="2.54" x2="2.54" y2="2.54" width="0.254" layer="94"/>
-<wire x1="2.54" y1="2.54" x2="2.54" y2="7.62" width="0.254" layer="94"/>
-<wire x1="2.54" y1="7.62" x2="2.54" y2="12.7" width="0.254" layer="94"/>
-<wire x1="2.54" y1="12.7" x2="5.08" y2="12.7" width="0.254" layer="94"/>
-<wire x1="5.08" y1="7.62" x2="2.54" y2="7.62" width="0.254" layer="94"/>
-<wire x1="2.54" y1="7.62" x2="0" y2="7.62" width="0.254" layer="94"/>
-<wire x1="7.62" y1="17.78" x2="9.144" y2="19.304" width="0.254" layer="94"/>
-<wire x1="9.144" y1="19.304" x2="8.128" y2="18.796" width="0.254" layer="94"/>
-<wire x1="8.636" y1="18.288" x2="9.144" y2="19.304" width="0.254" layer="94"/>
-<wire x1="6.096" y1="17.78" x2="7.62" y2="19.304" width="0.254" layer="94"/>
-<wire x1="7.62" y1="19.304" x2="6.604" y2="18.796" width="0.254" layer="94"/>
-<wire x1="7.112" y1="18.288" x2="7.62" y2="19.304" width="0.254" layer="94"/>
-<pin name="A" x="-2.54" y="7.62" visible="off" length="short"/>
-<pin name="B" x="12.7" y="2.54" visible="off" length="middle" rot="R180"/>
-<pin name="G" x="12.7" y="7.62" visible="off" length="middle" rot="R180"/>
-<pin name="R" x="12.7" y="12.7" visible="off" length="middle" rot="R180"/>
-<text x="5.08" y="16.51" size="1.27" layer="95" font="vector" ratio="15" align="center">&gt;NAME</text>
-<text x="10.922" y="12.954" size="1.27" layer="97">R</text>
-<text x="10.922" y="7.874" size="1.27" layer="97">G</text>
-<text x="10.922" y="2.794" size="1.27" layer="97">B</text>
-<text x="5.08" y="-1.27" size="0.889" layer="97" font="vector" ratio="15" align="center">&gt;MANF#</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -3180,32 +2730,6 @@ DIN A3, landscape with location and doc. field</description>
 </device>
 </devices>
 </deviceset>
-<deviceset name="LTST-C19HE1WT" urn="urn:adsk.eagle:component:20072928/3" prefix="LED" library_version="83" library_locally_modified="yes">
-<description>LED RGB DIFFUSED CHIP SMD</description>
-<gates>
-<gate name="G$1" symbol="RGB_LED" x="-2.54" y="-7.62"/>
-</gates>
-<devices>
-<device name="" package="0606">
-<connects>
-<connect gate="G$1" pin="A" pad="+"/>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="G" pad="G"/>
-<connect gate="G$1" pin="R" pad="R"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:20072926/2"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="DIGIKEY#" value="160-2162-1-ND" constant="no"/>
-<attribute name="MANF" value="Lite-On Inc" constant="no"/>
-<attribute name="MANF#" value="LTST-C19HE1WT" constant="no"/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
 </devicesets>
 </library>
 <library name="TVS_diodes" urn="urn:adsk.eagle:library:3333632">
@@ -3255,8 +2779,8 @@ DIN A3, landscape with location and doc. field</description>
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="PTVS33VP1UTP,115" urn="urn:adsk.eagle:component:11612760/1" prefix="D" library_version="22">
-<description>53.3V Clamp 11.3A Ipp Tvs Diode Surface Mount CFP5</description>
+<deviceset name="PTVS36VP1UP,115" urn="urn:adsk.eagle:component:6533207/2" prefix="D" library_version="7">
+<description>TVS DIODE CFP5</description>
 <gates>
 <gate name="G$1" symbol="TVS" x="0" y="0"/>
 </gates>
@@ -3271,9 +2795,9 @@ DIN A3, landscape with location and doc. field</description>
 </package3dinstances>
 <technologies>
 <technology name="-36V">
-<attribute name="DIGIKEY#" value="1727-1411-1-ND" constant="no"/>
+<attribute name="DIGIKEY#" value="1727-4439-2-ND" constant="no"/>
 <attribute name="MANF" value="Nexperia USA Inc" constant="no"/>
-<attribute name="MANF#" value="PTVS33VP1UTP,115" constant="no"/>
+<attribute name="MANF#" value="PTVS36VP1UP,115" constant="no"/>
 </technology>
 </technologies>
 </device>
@@ -3447,110 +2971,6 @@ http://www.bccomponents.com/</description>
 <text x="0" y="-1.5" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 <text x="-1.2" y="1.4" size="1.27" layer="21" font="vector" ratio="15" align="center">+</text>
 </package>
-<package name="R0402" urn="urn:adsk.eagle:footprint:2539434/1" library_version="46" library_locally_modified="yes">
-<smd name="1" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<smd name="2" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="12" align="center">&gt;NAME</text>
-<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
-<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
-<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
-<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
-<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
-<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
-<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
-<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
-</package>
-<package name="R0805" urn="urn:adsk.eagle:footprint:2539435/1" library_version="46" library_locally_modified="yes">
-<smd name="1" x="-1" y="0" dx="0.9" dy="1.3" layer="1"/>
-<smd name="2" x="1" y="0" dx="0.9" dy="1.3" layer="1"/>
-<wire x1="-1.65" y1="0.85" x2="1.65" y2="0.85" width="0.127" layer="21"/>
-<wire x1="1.65" y1="0.85" x2="1.65" y2="-0.85" width="0.127" layer="21"/>
-<wire x1="1.65" y1="-0.85" x2="-1.65" y2="-0.85" width="0.127" layer="21"/>
-<wire x1="-1.65" y1="-0.85" x2="-1.65" y2="0.85" width="0.127" layer="21"/>
-<text x="0" y="0" size="0.635" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="R0603" urn="urn:adsk.eagle:footprint:2539436/1" library_version="46" library_locally_modified="yes">
-<smd name="1" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
-<smd name="2" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
-<wire x1="-1.125" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
-<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
-<wire x1="1.125" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
-<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
-<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
-</package>
-<package name="R1206" urn="urn:adsk.eagle:footprint:2539441/1" library_version="46" library_locally_modified="yes">
-<smd name="P$1" x="-1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
-<smd name="P$2" x="1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
-<text x="0" y="0" size="0.762" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<wire x1="-2.2" y1="1" x2="2.2" y2="1" width="0.15" layer="21"/>
-<wire x1="2.2" y1="1" x2="2.2" y2="-1" width="0.15" layer="21"/>
-<wire x1="2.2" y1="-1" x2="-2.2" y2="-1" width="0.15" layer="21"/>
-<wire x1="-2.2" y1="-1" x2="-2.2" y2="1" width="0.15" layer="21"/>
-</package>
-<package name="R2512" urn="urn:adsk.eagle:footprint:1040086/1" library_version="46" library_locally_modified="yes">
-<description>http://www.resistor.com/assets/pdf/2512std.pdf</description>
-<smd name="1" x="-3.25" y="0" dx="3.2" dy="1.25" layer="1" rot="R90"/>
-<smd name="2" x="3.25" y="0" dx="3.2" dy="1.25" layer="1" rot="R90"/>
-<wire x1="-4.05" y1="1.75" x2="4.05" y2="1.75" width="0.1" layer="21"/>
-<wire x1="4.05" y1="1.75" x2="4.05" y2="-1.75" width="0.1" layer="21"/>
-<wire x1="4.05" y1="-1.75" x2="-4.05" y2="-1.75" width="0.1" layer="21"/>
-<wire x1="-4.05" y1="-1.75" x2="-4.05" y2="1.75" width="0.1" layer="21"/>
-<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="LED0402" urn="urn:adsk.eagle:footprint:2539447/1" library_version="54">
-<smd name="A" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<smd name="C" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<text x="0" y="0" size="0.4064" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
-<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
-<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
-<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
-<wire x1="-0.9" y1="0.45" x2="0.1" y2="0.45" width="0.1" layer="21"/>
-<wire x1="0.1" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
-<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
-<wire x1="0.9" y1="-0.45" x2="0.1" y2="-0.45" width="0.1" layer="21"/>
-<wire x1="0.1" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
-<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
-<wire x1="0.1" y1="0.45" x2="0.1" y2="-0.45" width="0.1" layer="21"/>
-</package>
-<package name="LED0603" urn="urn:adsk.eagle:footprint:2539448/1" library_version="54">
-<smd name="A" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
-<smd name="C" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
-<wire x1="-1.125" y1="0.55" x2="0.25" y2="0.55" width="0.1" layer="21"/>
-<wire x1="0.25" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
-<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
-<wire x1="1.125" y1="-0.55" x2="0.25" y2="-0.55" width="0.1" layer="21"/>
-<wire x1="0.25" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
-<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
-<wire x1="0.25" y1="0.55" x2="0.25" y2="-0.55" width="0.1" layer="21"/>
-<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
-</package>
-<package name="LED0805" urn="urn:adsk.eagle:footprint:2539449/1" library_version="54">
-<smd name="A" x="-1" y="0" dx="0.9" dy="1.3" layer="1"/>
-<smd name="C" x="1" y="0" dx="0.9" dy="1.3" layer="1"/>
-<wire x1="-1.65" y1="0.85" x2="0.4" y2="0.85" width="0.127" layer="21"/>
-<wire x1="0.4" y1="0.85" x2="1.65" y2="0.85" width="0.127" layer="21"/>
-<wire x1="1.65" y1="0.85" x2="1.65" y2="-0.85" width="0.127" layer="21"/>
-<wire x1="1.65" y1="-0.85" x2="0.4" y2="-0.85" width="0.127" layer="21"/>
-<wire x1="0.4" y1="-0.85" x2="-1.65" y2="-0.85" width="0.127" layer="21"/>
-<wire x1="-1.65" y1="-0.85" x2="-1.65" y2="0.85" width="0.127" layer="21"/>
-<wire x1="0.4" y1="0.85" x2="0.4" y2="-0.85" width="0.1" layer="21"/>
-<text x="0" y="0" size="0.635" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="LED1206" urn="urn:adsk.eagle:footprint:2539450/1" library_version="54">
-<smd name="A" x="-1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
-<smd name="C" x="1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
-<text x="0" y="0" size="0.762" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<wire x1="-2.2" y1="1" x2="0.9" y2="1" width="0.15" layer="21"/>
-<wire x1="0.9" y1="1" x2="2.2" y2="1" width="0.15" layer="21"/>
-<wire x1="2.2" y1="1" x2="2.2" y2="-1" width="0.15" layer="21"/>
-<wire x1="2.2" y1="-1" x2="0.9" y2="-1" width="0.15" layer="21"/>
-<wire x1="0.9" y1="-1" x2="-2.2" y2="-1" width="0.15" layer="21"/>
-<wire x1="-2.2" y1="-1" x2="-2.2" y2="1" width="0.15" layer="21"/>
-<wire x1="0.9" y1="1" x2="0.9" y2="-1" width="0.15" layer="21"/>
-</package>
 </packages>
 <packages3d>
 <package3d name="153CLV-0810" urn="urn:adsk.eagle:package:4491937/3" type="model" library_version="25" library_locally_modified="yes">
@@ -3624,52 +3044,6 @@ http://www.bccomponents.com/</description>
 <packageinstance name="RADIAL_6.3X12.5"/>
 </packageinstances>
 </package3d>
-<package3d name="R0402" urn="urn:adsk.eagle:package:2539456/2" type="model" library_version="46" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="R0402"/>
-</packageinstances>
-</package3d>
-<package3d name="R0805" urn="urn:adsk.eagle:package:2539455/2" type="model" library_version="46" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="R0805"/>
-</packageinstances>
-</package3d>
-<package3d name="R0603" urn="urn:adsk.eagle:package:2539454/2" type="model" library_version="46" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="R0603"/>
-</packageinstances>
-</package3d>
-<package3d name="R1206" urn="urn:adsk.eagle:package:2539464/2" type="model" library_version="46" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="R1206"/>
-</packageinstances>
-</package3d>
-<package3d name="R2512" urn="urn:adsk.eagle:package:4855216/2" type="model" library_version="46" library_locally_modified="yes">
-<description>http://www.resistor.com/assets/pdf/2512std.pdf</description>
-<packageinstances>
-<packageinstance name="R2512"/>
-</packageinstances>
-</package3d>
-<package3d name="LED0402" urn="urn:adsk.eagle:package:2539470/2" type="model" library_version="54">
-<packageinstances>
-<packageinstance name="LED0402"/>
-</packageinstances>
-</package3d>
-<package3d name="LED0603" urn="urn:adsk.eagle:package:2539471/2" type="model" library_version="54">
-<packageinstances>
-<packageinstance name="LED0603"/>
-</packageinstances>
-</package3d>
-<package3d name="LED0805" urn="urn:adsk.eagle:package:2539472/2" type="model" library_version="54">
-<packageinstances>
-<packageinstance name="LED0805"/>
-</packageinstances>
-</package3d>
-<package3d name="LED1206" urn="urn:adsk.eagle:package:2539473/2" type="model" library_version="54">
-<packageinstances>
-<packageinstance name="LED1206"/>
-</packageinstances>
-</package3d>
 </packages3d>
 <symbols>
 <symbol name="CPOL-1" urn="urn:adsk.eagle:symbol:4855519/1" library_version="25" library_locally_modified="yes">
@@ -3687,35 +3061,6 @@ http://www.bccomponents.com/</description>
 <text x="2.1844" y="1.0922" size="1.27" layer="94" ratio="15" align="center">+</text>
 <text x="-1.651" y="-0.9906" size="1.27" layer="96" font="vector" rot="R180" align="center-left">&gt;VALUE</text>
 <text x="-1.524" y="0.762" size="0.762" layer="97" font="vector" align="center-right">&gt;PACKAGE</text>
-</symbol>
-<symbol name="R-EU-1" urn="urn:adsk.eagle:symbol:2539432/2" library_version="46" library_locally_modified="yes">
-<wire x1="-2.54" y1="-0.889" x2="2.54" y2="-0.889" width="0.254" layer="94"/>
-<wire x1="2.54" y1="0.889" x2="-2.54" y2="0.889" width="0.254" layer="94"/>
-<wire x1="2.54" y1="-0.889" x2="2.54" y2="0.889" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="-0.889" x2="-2.54" y2="0.889" width="0.254" layer="94"/>
-<text x="0" y="0" size="1.27" layer="95" align="center">&gt;NAME</text>
-<text x="-0.254" y="-2.032" size="0.762" layer="96" align="bottom-right">&gt;VALUE</text>
-<text x="-3.81" y="0.508" size="0.508" layer="95" align="center">&gt;PACKAGE</text>
-<text x="0.254" y="-2.032" size="0.762" layer="96">&gt;TOLERANCE</text>
-<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
-</symbol>
-<symbol name="LED" urn="urn:adsk.eagle:symbol:2539429/1" library_version="54">
-<wire x1="-2.54" y1="1.27" x2="-2.54" y2="-1.27" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="-1.27" x2="0" y2="0" width="0.254" layer="94"/>
-<wire x1="0" y1="0" x2="-2.54" y2="1.27" width="0.254" layer="94"/>
-<wire x1="0" y1="1.27" x2="0" y2="0" width="0.254" layer="94"/>
-<wire x1="0" y1="0" x2="0" y2="-1.27" width="0.254" layer="94"/>
-<wire x1="0" y1="2.54" x2="1.524" y2="4.064" width="0.254" layer="94"/>
-<wire x1="1.524" y1="4.064" x2="0.508" y2="3.556" width="0.254" layer="94"/>
-<wire x1="1.016" y1="3.048" x2="1.524" y2="4.064" width="0.254" layer="94"/>
-<wire x1="-1.524" y1="2.54" x2="0" y2="4.064" width="0.254" layer="94"/>
-<wire x1="0" y1="4.064" x2="-1.016" y2="3.556" width="0.254" layer="94"/>
-<wire x1="-0.508" y1="3.048" x2="0" y2="4.064" width="0.254" layer="94"/>
-<pin name="A" x="-5.08" y="0" visible="off" length="short"/>
-<pin name="C" x="2.54" y="0" visible="off" length="short" rot="R180"/>
-<text x="-2.54" y="-2.54" size="1.27" layer="95" font="vector" ratio="15" align="center">&gt;NAME</text>
-<text x="-4.318" y="0.508" size="0.635" layer="96" font="vector" align="center">&gt;COLOR</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -3934,220 +3279,134 @@ http://www.bccomponents.com/</description>
 </device>
 </devices>
 </deviceset>
-<deviceset name="R" urn="urn:adsk.eagle:component:2539478/9" prefix="R" uservalue="yes" library_version="46" library_locally_modified="yes">
+</devicesets>
+</library>
+<library name="pinhead" urn="urn:adsk.eagle:library:2540341">
+<packages>
+<package name="1X02-PTH-2.54" urn="urn:adsk.eagle:footprint:2540357/1" library_version="30">
+<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="0.635" x2="-2.54" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-1.905" y1="1.27" x2="-2.54" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="-0.635" x2="-1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="-1.27" y="0" drill="1" diameter="1.7" rot="R90"/>
+<pad name="2" x="1.27" y="0" drill="1" diameter="1.7" rot="R90"/>
+<text x="0" y="0" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="37"/>
+<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="37"/>
+</package>
+<package name="1X02-PTH-2" urn="urn:adsk.eagle:footprint:6503390/2" library_version="30">
+<pad name="1" x="-1" y="0" drill="0.8" diameter="1.4"/>
+<pad name="2" x="1" y="0" drill="0.8" diameter="1.4"/>
+<wire x1="-1.5" y1="1" x2="-0.5" y2="1" width="0.15" layer="21"/>
+<wire x1="-0.5" y1="1" x2="0" y2="0.5" width="0.15" layer="21"/>
+<wire x1="0" y1="-0.5" x2="-0.5" y2="-1" width="0.15" layer="21"/>
+<wire x1="-0.5" y1="-1" x2="-1.5" y2="-1" width="0.15" layer="21"/>
+<wire x1="-1.5" y1="-1" x2="-2" y2="-0.5" width="0.15" layer="21"/>
+<wire x1="-2" y1="-0.5" x2="-2" y2="0.5" width="0.15" layer="21"/>
+<wire x1="-2" y1="0.5" x2="-1.5" y2="1" width="0.15" layer="21"/>
+<wire x1="0.5" y1="1" x2="1.5" y2="1" width="0.15" layer="21"/>
+<wire x1="1.5" y1="1" x2="2" y2="0.5" width="0.15" layer="21"/>
+<wire x1="2" y1="-0.5" x2="1.5" y2="-1" width="0.15" layer="21"/>
+<wire x1="1.5" y1="-1" x2="0.5" y2="-1" width="0.15" layer="21"/>
+<wire x1="0.5" y1="-1" x2="0" y2="-0.5" width="0.15" layer="21"/>
+<wire x1="0" y1="0.5" x2="0.5" y2="1" width="0.15" layer="21"/>
+<wire x1="2" y1="-0.5" x2="2" y2="0.5" width="0.15" layer="21"/>
+<text x="0" y="1.6" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="1X02-PTH-2-FEMALE" urn="urn:adsk.eagle:footprint:6503391/1" library_version="30">
+<pad name="1" x="-1" y="0" drill="0.8" diameter="1.4"/>
+<pad name="2" x="1" y="0" drill="0.8" diameter="1.4"/>
+<wire x1="-0.5" y1="-1" x2="-2" y2="-1" width="0.15" layer="25"/>
+<wire x1="-2" y1="-1" x2="-2" y2="0.5" width="0.15" layer="25"/>
+<wire x1="-2" y1="0.5" x2="-2" y2="1" width="0.15" layer="21"/>
+<wire x1="-2" y1="1" x2="2" y2="1" width="0.15" layer="21"/>
+<wire x1="2" y1="1" x2="2" y2="-0.5" width="0.15" layer="21"/>
+<wire x1="2" y1="-0.5" x2="2" y2="-1" width="0.15" layer="21"/>
+<wire x1="2" y1="-1" x2="-0.5" y2="-1" width="0.15" layer="21"/>
+<text x="0" y="1.6" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+</packages>
+<packages3d>
+<package3d name="1X02-PTH-2.54" urn="urn:adsk.eagle:package:2540385/2" type="model" library_version="30">
+<packageinstances>
+<packageinstance name="1X02-PTH-2.54"/>
+</packageinstances>
+</package3d>
+<package3d name="1X02-PTH-2" urn="urn:adsk.eagle:package:6503394/4" type="model" library_version="30">
+<packageinstances>
+<packageinstance name="1X02-PTH-2"/>
+</packageinstances>
+</package3d>
+<package3d name="1X02-PTH-2-FEMALE" urn="urn:adsk.eagle:package:6503395/3" type="model" library_version="30">
+<packageinstances>
+<packageinstance name="1X02-PTH-2-FEMALE"/>
+</packageinstances>
+</package3d>
+</packages3d>
+<symbols>
+<symbol name="M02" urn="urn:adsk.eagle:symbol:2540349/1" library_version="30">
+<wire x1="6.35" y1="0" x2="0" y2="0" width="0.4064" layer="94"/>
+<wire x1="3.81" y1="5.08" x2="5.08" y2="5.08" width="0.6096" layer="94"/>
+<wire x1="3.81" y1="2.54" x2="5.08" y2="2.54" width="0.6096" layer="94"/>
+<wire x1="0" y1="7.62" x2="0" y2="0" width="0.4064" layer="94"/>
+<wire x1="6.35" y1="0" x2="6.35" y2="7.62" width="0.4064" layer="94"/>
+<wire x1="0" y1="7.62" x2="6.35" y2="7.62" width="0.4064" layer="94"/>
+<text x="2.54" y="8.89" size="1.778" layer="95" font="vector" ratio="15" align="center">&gt;NAME</text>
+<pin name="1" x="7.62" y="2.54" visible="pin" length="short" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="2" x="7.62" y="5.08" visible="pin" length="short" direction="pas" swaplevel="1" rot="R180"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="PINHEAD_1X02" urn="urn:adsk.eagle:component:2540406/7" prefix="CON" library_version="30">
+<description>pinheader 2P</description>
 <gates>
-<gate name="G$1" symbol="R-EU-1" x="0" y="0"/>
+<gate name="G$1" symbol="M02" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="-0402" package="R0402">
+<device name="-2.54" package="1X02-PTH-2.54">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:2539456/2"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2540385/2"/>
 </package3dinstances>
 <technologies>
-<technology name="-1%">
-<attribute name="AEC-Q" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-<attribute name="PACKAGE" value="0402" constant="no"/>
-<attribute name="TOLERANCE" value="1%" constant="no"/>
-</technology>
-<technology name="-5%">
-<attribute name="AEC-Q" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-<attribute name="PACKAGE" value="0402" constant="no"/>
-<attribute name="TOLERANCE" value="5%" constant="no"/>
-</technology>
+<technology name=""/>
 </technologies>
 </device>
-<device name="-0805" package="R0805">
+<device name="-2" package="1X02-PTH-2">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:2539455/2"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6503394/4"/>
 </package3dinstances>
 <technologies>
-<technology name="-1%">
-<attribute name="AEC-Q" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-<attribute name="PACKAGE" value="0805" constant="no"/>
-<attribute name="TOLERANCE" value="1%" constant="no"/>
-</technology>
-<technology name="-5%">
-<attribute name="AEC-Q" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-<attribute name="PACKAGE" value="0805" constant="no"/>
-<attribute name="TOLERANCE" value="5%" constant="no"/>
-</technology>
+<technology name=""/>
 </technologies>
 </device>
-<device name="-0603" package="R0603">
+<device name="-2-FEMALE" package="1X02-PTH-2-FEMALE">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:2539454/2"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6503395/3"/>
 </package3dinstances>
 <technologies>
-<technology name="-1%">
-<attribute name="AEC-Q" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-<attribute name="PACKAGE" value="0603" constant="no"/>
-<attribute name="TOLERANCE" value="1%" constant="no"/>
-</technology>
-<technology name="-5%">
-<attribute name="AEC-Q" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-<attribute name="PACKAGE" value="0603" constant="no"/>
-<attribute name="TOLERANCE" value="5%" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-1206" package="R1206">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:2539464/2"/>
-</package3dinstances>
-<technologies>
-<technology name="-1%">
-<attribute name="AEC-Q" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-<attribute name="PACKAGE" value="1206" constant="no"/>
-<attribute name="TOLERANCE" value="1%" constant="no"/>
-</technology>
-<technology name="-5%">
-<attribute name="AEC-Q" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-<attribute name="PACKAGE" value="1206" constant="no"/>
-<attribute name="TOLERANCE" value="5%" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-2512" package="R2512">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:4855216/2"/>
-</package3dinstances>
-<technologies>
-<technology name="-1%">
-<attribute name="AEC-Q" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-<attribute name="PACKAGE" value="2512" constant="no"/>
-<attribute name="TOLERANCE" value="1%" constant="no"/>
-</technology>
-<technology name="-5%">
-<attribute name="AEC-Q" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-<attribute name="PACKAGE" value="2512" constant="no"/>
-<attribute name="TOLERANCE" value="5%" constant="no"/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="LED" urn="urn:adsk.eagle:component:2539475/3" prefix="LED" library_version="54">
-<description>SMD LED</description>
-<gates>
-<gate name="G$1" symbol="LED" x="2.54" y="0"/>
-</gates>
-<devices>
-<device name="-0402" package="LED0402">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:2539470/2"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="COLOR" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-0603" package="LED0603">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:2539471/2"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="COLOR" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-0805" package="LED0805">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:2539472/2"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="COLOR" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-1206" package="LED1206">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:2539473/2"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="COLOR" value="" constant="no"/>
-<attribute name="DIGIKEY#" value="" constant="no"/>
-<attribute name="MANF" value="" constant="no"/>
-<attribute name="MANF#" value="" constant="no"/>
-</technology>
+<technology name=""/>
 </technologies>
 </device>
 </devices>
@@ -4314,127 +3573,127 @@ http://www.bccomponents.com/</description>
 </classes>
 <parts>
 <part name="+P2" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="5V" device=""/>
-<part name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
+<part name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
+<part name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
+<part name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
+<part name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
+<part name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
+<part name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
+<part name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
+<part name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
 <part name="C10" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" deviceset="0.1µF" device="-0402" package3d_urn="urn:adsk.eagle:package:2539379/2" technology="-16V_10%_X7R" value="0.1µF"/>
@@ -4454,13 +3713,8 @@ http://www.bccomponents.com/</description>
 <part name="GND17" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GNDD" device="" value="GNDD"/>
 <part name="C14" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" deviceset="4.7µF" device="-0603" package3d_urn="urn:adsk.eagle:package:2539381/2" technology="-25V_10%_X6S" value="4.7µF"/>
 <part name="GND19" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GNDD" device="" value="GNDD"/>
-<part name="LED4" library="misc" library_urn="urn:adsk.eagle:library:5347860" deviceset="LTST-C19HE1WT" device="" package3d_urn="urn:adsk.eagle:package:20072926/2"/>
-<part name="LED2" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="LED" device="-0402" package3d_urn="urn:adsk.eagle:package:2539470/2" value="GREEN">
-<attribute name="COLOR" value="GREEN"/>
-<attribute name="DIGIKEY#" value="1830-IN-S42BT5GCT-ND"/>
-<attribute name="MANF" value="Inolux"/>
-<attribute name="MANF#" value="IN-S42BT5G"/>
-</part>
+<part name="LED4" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" deviceset="LTST-C19HE1WT" device="" package3d_urn="urn:adsk.eagle:package:1040199/2"/>
+<part name="LED2" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" deviceset="LED" device="-0402" package3d_urn="urn:adsk.eagle:package:1040216/2" technology="-GREEN" value="GREEN"/>
 <part name="+P9" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="5V" device=""/>
 <part name="R5" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="1K" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-1%" value="1K"/>
 <part name="R6" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="1K" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-1%" value="1K"/>
@@ -4472,21 +3726,21 @@ http://www.bccomponents.com/</description>
 <part name="GND5" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="PGND" device="" value="PGND"/>
 <part name="+P6" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="VDC" device=""/>
 <part name="+P4" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="VDC" device=""/>
-<part name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5">
+<part name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="R4" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" deviceset="CURRENT_SHUNT_KELVIN" device="-2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" technology="-0.010R" value="10 mOhms"/>
+<part name="R4" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" deviceset="CURRENT_SHUNT_KELVIN" device="-2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" technology="-0.005R" value="5 mOhms"/>
 <part name="IC1" library="misc" library_urn="urn:adsk.eagle:library:5347860" deviceset="MCP9700" device="-SC70-5" package3d_urn="urn:adsk.eagle:package:7365869/3"/>
 <part name="C5" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" deviceset="0.1µF" device="-0402" package3d_urn="urn:adsk.eagle:package:2539379/2" technology="-16V_10%_X7R" value="0.1µF"/>
 <part name="R1" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="4R3" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-5%" value="4R3"/>
 <part name="R2" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="4R3" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-5%" value="4R3"/>
-<part name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5">
+<part name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="R10" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" deviceset="CURRENT_SHUNT_KELVIN" device="-2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" technology="-0.010R" value="10 mOhms"/>
+<part name="R10" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" deviceset="CURRENT_SHUNT_KELVIN" device="-2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" technology="-0.005R" value="5 mOhms"/>
 <part name="R8" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="4R3" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-5%" value="4R3"/>
 <part name="R9" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="4R3" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-5%" value="4R3"/>
-<part name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5">
+<part name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5">
 <variant name="Basic" populate="no"/>
 </part>
 <part name="R11" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="4R3" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-5%" value="4R3"/>
@@ -4519,7 +3773,7 @@ http://www.bccomponents.com/</description>
 <variant name="Basic" populate="no"/>
 </part>
 <part name="GND2" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="PGND" device="" value="PGND"/>
-<part name="D1" library="TVS_diodes" library_urn="urn:adsk.eagle:library:3333632" deviceset="PTVS33VP1UTP,115" device="-SOD128" package3d_urn="urn:adsk.eagle:package:6533206/2" technology="-36V"/>
+<part name="D1" library="TVS_diodes" library_urn="urn:adsk.eagle:library:3333632" deviceset="PTVS36VP1UP,115" device="-SOD128" package3d_urn="urn:adsk.eagle:package:6533206/2" technology="-36V"/>
 <part name="C1" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="CPOL" device="-RADIAL_SIDE-8X21.5" package3d_urn="urn:adsk.eagle:package:7189333/3" value="180µF">
 <variant name="nocaps" populate="no"/>
 </part>
@@ -4530,6 +3784,9 @@ http://www.bccomponents.com/</description>
 <part name="+P5" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="VDC" device=""/>
 <part name="C2" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="CPOL" device="-RADIAL_SIDE-8X21.5" package3d_urn="urn:adsk.eagle:package:7189333/3" value="180µF">
 <variant name="nocaps" populate="no"/>
+</part>
+<part name="CON3" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" deviceset="PINHEAD_1X02" device="-2.54" package3d_urn="urn:adsk.eagle:package:2540385/2">
+<variant name="Basic" populate="no"/>
 </part>
 <part name="+P3" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="VDC" device=""/>
 <part name="+P1" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="VDC" device=""/>
@@ -4557,22 +3814,14 @@ http://www.bccomponents.com/</description>
 <part name="GND11" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 <part name="GND21" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 <part name="GND6" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
-<part name="LED1" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="LED" device="-0402" package3d_urn="urn:adsk.eagle:package:2539470/2" value="GREEN">
-<variant name="Basic" populate="no" value="LED-0402"/>
-</part>
-<part name="LED3" library="misc" library_urn="urn:adsk.eagle:library:5347860" deviceset="LTST-C19HE1WT" device="" package3d_urn="urn:adsk.eagle:package:20072926/2">
+<part name="LED1" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" deviceset="LED" device="-0402" package3d_urn="urn:adsk.eagle:package:1040216/2" technology="-GREEN" value="GREEN">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="R14" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="R" device="-0402" package3d_urn="urn:adsk.eagle:package:2539456/2" technology="-1%" value="680R">
-<attribute name="AEC-Q" value="AEC-Q200"/>
-<attribute name="DIGIKEY#" value="CRCW0402680RFKEDDatasheet "/>
-<attribute name="MANF" value="Vishay Dale"/>
-<attribute name="MANF#" value="CRCW0402680RFKED"/>
+<part name="LED3" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" deviceset="LTST-C19HE1WT" device="" package3d_urn="urn:adsk.eagle:package:1040199/2">
+<variant name="Basic" populate="no"/>
 </part>
+<part name="R14" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="1K" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-1%" value="1K"/>
 <part name="GND25" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
-<part name="PAD47" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-S-1.5" package3d_urn="urn:adsk.eagle:package:15477730/1"/>
-<part name="PAD48" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-S-1.5" package3d_urn="urn:adsk.eagle:package:15477730/1"/>
-<part name="FRAME2" library="frames" library_urn="urn:adsk.eagle:library:229" deviceset="A5L-LOC" device=""/>
 </parts>
 <sheets>
 <sheet>
@@ -4587,16 +3836,16 @@ http://www.bccomponents.com/</description>
 <wire x1="60.96" y1="167.64" x2="60.96" y2="83.82" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="10.16" y1="167.64" x2="60.96" y2="167.64" width="0.1524" layer="97" style="shortdash"/>
 <text x="43.18" y="165.1" size="1.778" layer="97" font="vector" align="center">High side interface</text>
-<wire x1="288.29" y1="63.5" x2="288.29" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="223.52" y1="63.5" x2="288.29" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="288.29" y1="134.62" x2="223.52" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="223.52" y1="134.62" x2="223.52" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
-<text x="243.84" y="132.08" size="2.54" layer="97" font="vector" align="center-left">INDICATION</text>
-<text x="132.08" y="248.92" size="1.27" layer="97" font="vector">The minimum specific bulk capacitance is 20 μF/A 
+<wire x1="285.75" y1="69.85" x2="285.75" y2="142.24" width="0.1524" layer="97" style="shortdash"/>
+<wire x1="220.98" y1="69.85" x2="285.75" y2="69.85" width="0.1524" layer="97" style="shortdash"/>
+<wire x1="285.75" y1="142.24" x2="220.98" y2="142.24" width="0.1524" layer="97" style="shortdash"/>
+<wire x1="220.98" y1="142.24" x2="220.98" y2="69.85" width="0.1524" layer="97" style="shortdash"/>
+<text x="228.6" y="144.78" size="2.54" layer="97" font="vector" align="center-left">INDICATION</text>
+<text x="132.08" y="248.92" size="1.27" layer="97">The minimum specific bulk capacitance is 20 μF/A 
 (e.g. an ESC rated for 20 A DC requires at least 400 μF).</text>
-<text x="193.04" y="241.3" size="2.54" layer="97" font="vector">PHASE_A</text>
-<text x="256.54" y="241.3" size="2.54" layer="97" font="vector">PHASE_B</text>
-<text x="317.5" y="241.3" size="2.54" layer="97" font="vector">PHASE_C</text>
+<text x="193.04" y="236.22" size="2.54" layer="97">PHASE_A</text>
+<text x="256.54" y="236.22" size="2.54" layer="97">PHASE_B</text>
+<text x="317.5" y="236.22" size="2.54" layer="97">PHASE_C</text>
 <wire x1="190.5" y1="246.38" x2="254" y2="246.38" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="254" y1="246.38" x2="314.96" y2="246.38" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="314.96" y1="246.38" x2="375.92" y2="246.38" width="0.1524" layer="97" style="shortdash"/>
@@ -4613,62 +3862,17 @@ http://www.bccomponents.com/</description>
 <wire x1="132.08" y1="205.74" x2="190.5" y2="205.74" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="190.246" y1="164.084" x2="131.826" y2="164.084" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="131.826" y1="164.084" x2="132.08" y2="205.74" width="0.1524" layer="97" style="shortdash"/>
-<text x="134.62" y="213.36" size="2.54" layer="97" font="vector">Capacitor battery</text>
-<text x="134.62" y="208.28" size="1.27" layer="97" font="vector">These capacitors should be placed 
+<text x="134.62" y="213.36" size="2.54" layer="97">Capacitor battery</text>
+<text x="134.62" y="208.28" size="1.27" layer="97">These capacitors should be placed 
 as close as possible to the power transistors.</text>
-<text x="134.62" y="200.66" size="3.048" layer="97" font="vector">Temperature sensor</text>
-<text x="134.62" y="165.1" size="2.54" layer="97" font="vector">Place close to power mosfets</text>
+<text x="134.62" y="198.12" size="1.778" layer="97">Temperature sensor</text>
+<text x="134.62" y="160.02" size="2.54" layer="97">Place close to power mosfets</text>
+<text x="233.68" y="38.1" size="1.778" layer="91">https://www.digikey.com/product-detail/en/united-chemi-con/EKZN500ELL181MH20D/565-4066-ND/4843876</text>
 <wire x1="289.56" y1="134.62" x2="289.56" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="289.56" y1="63.5" x2="375.92" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
+<wire x1="289.56" y1="63.5" x2="368.3" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
+<wire x1="368.3" y1="63.5" x2="375.92" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="375.92" y1="63.5" x2="375.92" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="375.92" y1="134.62" x2="289.56" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
-<text x="17.78" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">DC power, W</text>
-<text x="35.56" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">Phase current, I</text>
-<text x="55.88" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">Total losses, W</text>
-<text x="78.74" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">Efficiency, %</text>
-<text x="17.78" y="30.48" size="1.27" layer="97" font="vector" ratio="15" align="center">100</text>
-<text x="17.78" y="27.94" size="1.27" layer="97" font="vector" ratio="15" align="center">150</text>
-<text x="17.78" y="25.4" size="1.27" layer="97" font="vector" ratio="15" align="center">200</text>
-<text x="17.78" y="22.86" size="1.27" layer="97" font="vector" ratio="15" align="center">250</text>
-<text x="17.78" y="20.32" size="1.27" layer="97" font="vector" ratio="15" align="center">300</text>
-<text x="48.26" y="15.24" size="1.27" layer="97" font="vector" ratio="15" align="center">The table is valid for 26.4 V supply voltage
-which is the same as a discharched 8S Li-ion battery</text>
-<text x="35.56" y="30.48" size="1.27" layer="97" font="vector" ratio="15" align="center">4.8</text>
-<text x="55.88" y="30.48" size="1.27" layer="97" font="vector" ratio="15" align="center">1.7</text>
-<text x="78.74" y="30.48" size="1.27" layer="97" font="vector" ratio="15" align="center">98.3</text>
-<text x="35.56" y="27.94" size="1.27" layer="97" font="vector" ratio="15" align="center">7.2</text>
-<text x="55.88" y="27.94" size="1.27" layer="97" font="vector" ratio="15" align="center">3</text>
-<text x="78.74" y="27.94" size="1.27" layer="97" font="vector" ratio="15" align="center">98</text>
-<text x="35.56" y="25.4" size="1.27" layer="97" font="vector" ratio="15" align="center">9.6</text>
-<text x="55.88" y="25.4" size="1.27" layer="97" font="vector" ratio="15" align="center">4.5</text>
-<text x="78.74" y="25.4" size="1.27" layer="97" font="vector" ratio="15" align="center">97.7</text>
-<text x="35.56" y="22.86" size="1.27" layer="97" font="vector" ratio="15" align="center">12</text>
-<text x="55.88" y="22.86" size="1.27" layer="97" font="vector" ratio="15" align="center">6.3</text>
-<text x="78.74" y="22.86" size="1.27" layer="97" font="vector" ratio="15" align="center">97.5</text>
-<text x="35.56" y="20.32" size="1.27" layer="97" font="vector" ratio="15" align="center">14.4</text>
-<text x="55.88" y="20.32" size="1.27" layer="97" font="vector" ratio="15" align="center">8.4</text>
-<text x="78.74" y="20.32" size="1.27" layer="97" font="vector" ratio="15" align="center">97.2</text>
-<text x="50.8" y="40.64" size="1.27" layer="97" font="vector" ratio="15" align="center">Power losses for different power levels</text>
-<text x="63.5" y="111.76" size="1.778" layer="97" font="vector" ratio="15" align="center-left">R14 sets overcurrent protection trip level. 
-680R sets ir arount 35A, which is 2.5 times 
-higher than maximum phase current for 300W DC power 
-when running on discharged 8S battery</text>
-<wire x1="10.16" y1="38.1" x2="25.4" y2="38.1" width="0.1524" layer="97"/>
-<wire x1="25.4" y1="38.1" x2="45.72" y2="38.1" width="0.1524" layer="97"/>
-<wire x1="45.72" y1="38.1" x2="68.58" y2="38.1" width="0.1524" layer="97"/>
-<wire x1="68.58" y1="38.1" x2="88.9" y2="38.1" width="0.1524" layer="97"/>
-<wire x1="88.9" y1="38.1" x2="88.9" y2="33.02" width="0.1524" layer="97"/>
-<wire x1="88.9" y1="33.02" x2="88.9" y2="17.78" width="0.1524" layer="97"/>
-<wire x1="88.9" y1="17.78" x2="68.58" y2="17.78" width="0.1524" layer="97"/>
-<wire x1="68.58" y1="17.78" x2="45.72" y2="17.78" width="0.1524" layer="97"/>
-<wire x1="45.72" y1="17.78" x2="25.4" y2="17.78" width="0.1524" layer="97"/>
-<wire x1="25.4" y1="17.78" x2="10.16" y2="17.78" width="0.1524" layer="97"/>
-<wire x1="10.16" y1="17.78" x2="10.16" y2="33.02" width="0.1524" layer="97"/>
-<wire x1="10.16" y1="33.02" x2="10.16" y2="38.1" width="0.1524" layer="97"/>
-<wire x1="10.16" y1="33.02" x2="88.9" y2="33.02" width="0.1524" layer="97"/>
-<wire x1="68.58" y1="38.1" x2="68.58" y2="17.78" width="0.1524" layer="97"/>
-<wire x1="45.72" y1="38.1" x2="45.72" y2="17.78" width="0.1524" layer="97"/>
-<wire x1="25.4" y1="38.1" x2="25.4" y2="17.78" width="0.1524" layer="97"/>
 </plain>
 <instances>
 <instance part="+P2" gate="G$1" x="45.72" y="238.76" smashed="yes">
@@ -4797,11 +4001,11 @@ when running on discharged 8S battery</text>
 <instance part="PAD1" gate="G$1" x="48.26" y="160.02" smashed="yes" rot="MR0">
 <attribute name="NAME" x="48.26" y="161.29" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
-<instance part="C10" gate="G$1" x="299.72" y="114.3" smashed="yes" rot="R270">
-<attribute name="NAME" x="298.831" y="113.03" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
-<attribute name="VALUE" x="299.974" y="115.57" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
-<attribute name="PACKAGE" x="299.212" y="116.332" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
-<attribute name="VOLTAGE" x="299.974" y="112.014" size="0.762" layer="96" font="vector" rot="R270" align="bottom-center"/>
+<instance part="C10" gate="G$1" x="299.72" y="116.84" smashed="yes" rot="R270">
+<attribute name="NAME" x="298.831" y="115.57" size="1.27" layer="95" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="299.974" y="118.11" size="0.762" layer="96" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="299.212" y="118.872" size="0.508" layer="97" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="299.974" y="114.554" size="0.762" layer="96" rot="R270" align="bottom-center"/>
 </instance>
 <instance part="CON1" gate="G$1" x="365.76" y="129.54" smashed="yes" rot="R270">
 <attribute name="NAME" x="372.11" y="123.19" size="1.778" layer="95" font="vector" ratio="15" rot="R90" align="center"/>
@@ -4831,22 +4035,22 @@ when running on discharged 8S battery</text>
 <attribute name="VALUE" x="302.26" y="87.376" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
 <instance part="C11" gate="G$1" x="302.26" y="76.2" smashed="yes" rot="R270">
-<attribute name="NAME" x="301.371" y="74.93" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
-<attribute name="VALUE" x="302.514" y="77.47" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
-<attribute name="PACKAGE" x="301.752" y="78.232" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
-<attribute name="VOLTAGE" x="302.514" y="73.914" size="0.762" layer="96" font="vector" rot="R270" align="bottom-center"/>
+<attribute name="NAME" x="301.371" y="74.93" size="1.27" layer="95" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="302.514" y="77.47" size="0.762" layer="96" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="301.752" y="78.232" size="0.508" layer="97" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="302.514" y="73.914" size="0.762" layer="96" rot="R270" align="bottom-center"/>
 </instance>
 <instance part="C13" gate="G$1" x="340.36" y="76.2" smashed="yes" rot="R90">
-<attribute name="NAME" x="341.249" y="77.47" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="340.106" y="74.93" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="340.868" y="74.168" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="340.106" y="78.486" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="341.249" y="77.47" size="1.27" layer="95" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="340.106" y="74.93" size="0.762" layer="96" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="340.868" y="74.168" size="0.508" layer="97" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="340.106" y="78.486" size="0.762" layer="96" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="C12" gate="G$1" x="335.28" y="76.2" smashed="yes" rot="R90">
-<attribute name="NAME" x="336.169" y="77.47" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="335.026" y="74.93" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="335.788" y="74.168" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="335.026" y="78.486" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="336.169" y="77.47" size="1.27" layer="95" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="335.026" y="74.93" size="0.762" layer="96" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="335.788" y="74.168" size="0.508" layer="97" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="335.026" y="78.486" size="0.762" layer="96" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="GND16" gate="G$1" x="335.28" y="68.58" smashed="yes">
 <attribute name="VALUE" x="335.28" y="66.548" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
@@ -4855,68 +4059,67 @@ when running on discharged 8S battery</text>
 <attribute name="VALUE" x="340.36" y="66.548" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
 <instance part="C14" gate="G$1" x="345.44" y="76.2" smashed="yes" rot="R90">
-<attribute name="NAME" x="346.329" y="77.47" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="345.186" y="74.93" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="345.948" y="74.168" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="345.186" y="78.486" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="346.329" y="77.47" size="1.27" layer="95" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="345.186" y="74.93" size="0.762" layer="96" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="345.948" y="74.168" size="0.508" layer="97" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="345.186" y="78.486" size="0.762" layer="96" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="GND19" gate="G$1" x="345.44" y="68.58" smashed="yes">
 <attribute name="VALUE" x="345.44" y="66.548" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="LED4" gate="G$1" x="266.7" y="116.84" smashed="yes" rot="R270">
-<attribute name="NAME" x="283.21" y="111.76" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
-<attribute name="MANF#" x="265.43" y="111.76" size="0.889" layer="97" font="vector" ratio="15" rot="R270" align="center"/>
+<instance part="LED4" gate="G$1" x="264.16" y="121.92" smashed="yes" rot="R270">
+<attribute name="NAME" x="280.416" y="116.84" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
 </instance>
-<instance part="LED2" gate="G$1" x="233.68" y="114.3" smashed="yes" rot="R270">
-<attribute name="NAME" x="231.14" y="116.84" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
-<attribute name="COLOR" x="234.188" y="118.618" size="0.635" layer="96" font="vector" rot="R270" align="center"/>
+<instance part="LED2" gate="G$1" x="231.14" y="121.92" smashed="yes" rot="R270">
+<attribute name="COLOR" x="231.14" y="121.92" size="1.27" layer="96" font="vector" rot="R270" align="center-left" display="off"/>
+<attribute name="NAME" x="232.918" y="124.46" size="1.27" layer="95" rot="R270"/>
 </instance>
-<instance part="+P9" gate="G$1" x="233.68" y="127" smashed="yes">
-<attribute name="VALUE" x="233.68" y="130.556" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="+P9" gate="G$1" x="231.14" y="132.08" smashed="yes">
+<attribute name="VALUE" x="231.14" y="135.636" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="R5" gate="G$1" x="269.24" y="88.9" smashed="yes" rot="MR270">
-<attribute name="NAME" x="269.24" y="88.9" size="1.27" layer="95" font="vector" rot="MR270" align="center"/>
-<attribute name="VALUE" x="271.272" y="89.154" size="0.762" layer="96" font="vector" rot="MR270" align="bottom-right"/>
-<attribute name="PACKAGE" x="268.732" y="92.71" size="0.508" layer="95" font="vector" rot="MR270" align="center"/>
-<attribute name="TOLERANCE" x="271.272" y="88.646" size="0.762" layer="96" font="vector" rot="MR270"/>
+<instance part="R5" gate="G$1" x="266.7" y="93.98" smashed="yes" rot="MR270">
+<attribute name="NAME" x="266.7" y="93.98" size="1.27" layer="95" rot="MR270" align="center"/>
+<attribute name="VALUE" x="268.732" y="94.234" size="0.762" layer="96" rot="MR270" align="bottom-right"/>
+<attribute name="PACKAGE" x="266.192" y="97.79" size="0.508" layer="95" rot="MR270" align="center"/>
+<attribute name="TOLERANCE" x="268.732" y="93.726" size="0.762" layer="96" rot="MR270"/>
 </instance>
-<instance part="R6" gate="G$1" x="274.32" y="88.9" smashed="yes" rot="MR270">
-<attribute name="NAME" x="274.32" y="88.9" size="1.27" layer="95" font="vector" rot="MR270" align="center"/>
-<attribute name="VALUE" x="276.352" y="89.154" size="0.762" layer="96" font="vector" rot="MR270" align="bottom-right"/>
-<attribute name="PACKAGE" x="273.812" y="92.71" size="0.508" layer="95" font="vector" rot="MR270" align="center"/>
-<attribute name="TOLERANCE" x="276.352" y="88.646" size="0.762" layer="96" font="vector" rot="MR270"/>
+<instance part="R6" gate="G$1" x="271.78" y="93.98" smashed="yes" rot="MR270">
+<attribute name="NAME" x="271.78" y="93.98" size="1.27" layer="95" rot="MR270" align="center"/>
+<attribute name="VALUE" x="273.812" y="94.234" size="0.762" layer="96" rot="MR270" align="bottom-right"/>
+<attribute name="PACKAGE" x="271.272" y="97.79" size="0.508" layer="95" rot="MR270" align="center"/>
+<attribute name="TOLERANCE" x="273.812" y="93.726" size="0.762" layer="96" rot="MR270"/>
 </instance>
-<instance part="R7" gate="G$1" x="279.4" y="88.9" smashed="yes" rot="MR270">
-<attribute name="NAME" x="279.4" y="88.9" size="1.27" layer="95" font="vector" rot="MR270" align="center"/>
-<attribute name="VALUE" x="281.432" y="89.154" size="0.762" layer="96" font="vector" rot="MR270" align="bottom-right"/>
-<attribute name="PACKAGE" x="278.892" y="92.71" size="0.508" layer="95" font="vector" rot="MR270" align="center"/>
-<attribute name="TOLERANCE" x="281.432" y="88.646" size="0.762" layer="96" font="vector" rot="MR270"/>
+<instance part="R7" gate="G$1" x="276.86" y="93.98" smashed="yes" rot="MR270">
+<attribute name="NAME" x="276.86" y="93.98" size="1.27" layer="95" rot="MR270" align="center"/>
+<attribute name="VALUE" x="278.892" y="94.234" size="0.762" layer="96" rot="MR270" align="bottom-right"/>
+<attribute name="PACKAGE" x="276.352" y="97.79" size="0.508" layer="95" rot="MR270" align="center"/>
+<attribute name="TOLERANCE" x="278.892" y="93.726" size="0.762" layer="96" rot="MR270"/>
 </instance>
-<instance part="+P11" gate="G$1" x="274.32" y="127" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="274.32" y="130.556" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
+<instance part="+P11" gate="G$1" x="271.78" y="132.08" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="271.78" y="135.636" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
-<instance part="R3" gate="G$1" x="233.68" y="101.6" smashed="yes" rot="R90">
-<attribute name="NAME" x="233.68" y="101.6" size="1.27" layer="95" font="vector" rot="R90" align="center"/>
-<attribute name="VALUE" x="235.712" y="101.346" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="233.172" y="97.79" size="0.508" layer="95" font="vector" rot="R90" align="center"/>
-<attribute name="TOLERANCE" x="235.712" y="101.854" size="0.762" layer="96" font="vector" rot="R90"/>
+<instance part="R3" gate="G$1" x="231.14" y="106.68" smashed="yes" rot="R90">
+<attribute name="NAME" x="231.14" y="106.68" size="1.27" layer="95" rot="R90" align="center"/>
+<attribute name="VALUE" x="233.172" y="106.426" size="0.762" layer="96" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="230.632" y="102.87" size="0.508" layer="95" rot="R90" align="center"/>
+<attribute name="TOLERANCE" x="233.172" y="106.934" size="0.762" layer="96" rot="R90"/>
 </instance>
 <instance part="FRAME1" gate="G$1" x="0" y="0" smashed="yes">
-<attribute name="DRAWING_NAME" x="344.17" y="15.24" size="2.54" layer="94" font="vector"/>
-<attribute name="LAST_DATE_TIME" x="344.17" y="10.16" size="2.286" layer="94" font="vector"/>
-<attribute name="SHEET" x="357.505" y="5.08" size="2.54" layer="94" font="vector"/>
+<attribute name="DRAWING_NAME" x="344.17" y="15.24" size="2.54" layer="94"/>
+<attribute name="LAST_DATE_TIME" x="344.17" y="10.16" size="2.286" layer="94"/>
+<attribute name="SHEET" x="357.505" y="5.08" size="2.54" layer="94"/>
 </instance>
-<instance part="GND3" gate="G$1" x="142.24" y="220.98" smashed="yes">
-<attribute name="VALUE" x="142.24" y="219.71" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
+<instance part="GND3" gate="G$1" x="142.24" y="223.52" smashed="yes">
+<attribute name="VALUE" x="142.24" y="222.25" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="GND5" gate="G$1" x="157.48" y="220.98" smashed="yes">
-<attribute name="VALUE" x="157.48" y="219.71" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
+<instance part="GND5" gate="G$1" x="157.48" y="223.52" smashed="yes">
+<attribute name="VALUE" x="157.48" y="222.25" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="+P6" gate="G$1" x="157.48" y="238.76" smashed="yes">
-<attribute name="VALUE" x="157.48" y="242.316" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="+P6" gate="G$1" x="157.48" y="236.22" smashed="yes">
+<attribute name="VALUE" x="157.48" y="239.776" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="+P4" gate="G$1" x="142.24" y="238.76" smashed="yes">
-<attribute name="VALUE" x="142.24" y="242.316" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="+P4" gate="G$1" x="142.24" y="236.22" smashed="yes">
+<attribute name="VALUE" x="142.24" y="239.776" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
 <instance part="PAD44" gate="G$1" x="241.3" y="220.98" smashed="yes" rot="MR0">
 <attribute name="NAME" x="241.3" y="222.25" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
@@ -4930,22 +4133,22 @@ when running on discharged 8S battery</text>
 <attribute name="MANF#" x="181.61" y="182.626" size="0.762" layer="95" font="vector" ratio="15" rot="R180" align="bottom-center"/>
 </instance>
 <instance part="C5" gate="G$1" x="167.64" y="182.88" smashed="yes" rot="R270">
-<attribute name="NAME" x="166.751" y="181.61" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
-<attribute name="VALUE" x="167.894" y="184.15" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
-<attribute name="PACKAGE" x="167.132" y="184.912" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
-<attribute name="VOLTAGE" x="167.894" y="180.594" size="0.762" layer="96" font="vector" rot="R270" align="bottom-center"/>
+<attribute name="NAME" x="166.751" y="181.61" size="1.27" layer="95" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="167.894" y="184.15" size="0.762" layer="96" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="167.132" y="184.912" size="0.508" layer="97" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="167.894" y="180.594" size="0.762" layer="96" rot="R270" align="bottom-center"/>
 </instance>
 <instance part="R1" gate="G$1" x="220.98" y="228.6" smashed="yes">
-<attribute name="NAME" x="220.98" y="228.6" size="1.27" layer="95" font="vector" align="center"/>
-<attribute name="VALUE" x="220.726" y="226.568" size="0.762" layer="96" font="vector" align="bottom-right"/>
-<attribute name="PACKAGE" x="217.17" y="229.108" size="0.508" layer="95" font="vector" align="center"/>
-<attribute name="TOLERANCE" x="221.234" y="226.568" size="0.762" layer="96" font="vector"/>
+<attribute name="NAME" x="220.98" y="228.6" size="1.27" layer="95" align="center"/>
+<attribute name="VALUE" x="220.726" y="226.568" size="0.762" layer="96" align="bottom-right"/>
+<attribute name="PACKAGE" x="217.17" y="229.108" size="0.508" layer="95" align="center"/>
+<attribute name="TOLERANCE" x="221.234" y="226.568" size="0.762" layer="96"/>
 </instance>
 <instance part="R2" gate="G$1" x="220.98" y="213.36" smashed="yes">
-<attribute name="NAME" x="220.98" y="213.36" size="1.27" layer="95" font="vector" align="center"/>
-<attribute name="VALUE" x="220.726" y="211.328" size="0.762" layer="96" font="vector" align="bottom-right"/>
-<attribute name="PACKAGE" x="217.17" y="213.868" size="0.508" layer="95" font="vector" align="center"/>
-<attribute name="TOLERANCE" x="221.234" y="211.328" size="0.762" layer="96" font="vector"/>
+<attribute name="NAME" x="220.98" y="213.36" size="1.27" layer="95" align="center"/>
+<attribute name="VALUE" x="220.726" y="211.328" size="0.762" layer="96" align="bottom-right"/>
+<attribute name="PACKAGE" x="217.17" y="213.868" size="0.508" layer="95" align="center"/>
+<attribute name="TOLERANCE" x="221.234" y="211.328" size="0.762" layer="96"/>
 </instance>
 <instance part="PAD45" gate="G$1" x="307.34" y="218.44" smashed="yes" rot="MR0">
 <attribute name="NAME" x="307.34" y="219.71" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
@@ -4955,56 +4158,56 @@ when running on discharged 8S battery</text>
 <attribute name="VALUE" x="299.72" y="182.88" size="1.016" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
 </instance>
 <instance part="R8" gate="G$1" x="287.02" y="226.06" smashed="yes">
-<attribute name="NAME" x="287.02" y="226.06" size="1.27" layer="95" font="vector" align="center"/>
-<attribute name="VALUE" x="286.766" y="224.028" size="0.762" layer="96" font="vector" align="bottom-right"/>
-<attribute name="PACKAGE" x="283.21" y="226.568" size="0.508" layer="95" font="vector" align="center"/>
-<attribute name="TOLERANCE" x="287.274" y="224.028" size="0.762" layer="96" font="vector"/>
+<attribute name="NAME" x="287.02" y="226.06" size="1.27" layer="95" align="center"/>
+<attribute name="VALUE" x="286.766" y="224.028" size="0.762" layer="96" align="bottom-right"/>
+<attribute name="PACKAGE" x="283.21" y="226.568" size="0.508" layer="95" align="center"/>
+<attribute name="TOLERANCE" x="287.274" y="224.028" size="0.762" layer="96"/>
 </instance>
 <instance part="R9" gate="G$1" x="287.02" y="210.82" smashed="yes">
-<attribute name="NAME" x="287.02" y="210.82" size="1.27" layer="95" font="vector" align="center"/>
-<attribute name="VALUE" x="286.766" y="208.788" size="0.762" layer="96" font="vector" align="bottom-right"/>
-<attribute name="PACKAGE" x="283.21" y="211.328" size="0.508" layer="95" font="vector" align="center"/>
-<attribute name="TOLERANCE" x="287.274" y="208.788" size="0.762" layer="96" font="vector"/>
+<attribute name="NAME" x="287.02" y="210.82" size="1.27" layer="95" align="center"/>
+<attribute name="VALUE" x="286.766" y="208.788" size="0.762" layer="96" align="bottom-right"/>
+<attribute name="PACKAGE" x="283.21" y="211.328" size="0.508" layer="95" align="center"/>
+<attribute name="TOLERANCE" x="287.274" y="208.788" size="0.762" layer="96"/>
 </instance>
 <instance part="PAD46" gate="G$1" x="368.3" y="218.44" smashed="yes" rot="MR0">
 <attribute name="NAME" x="368.3" y="219.71" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
 <instance part="R11" gate="G$1" x="347.98" y="226.06" smashed="yes">
-<attribute name="NAME" x="347.98" y="226.06" size="1.27" layer="95" font="vector" align="center"/>
-<attribute name="VALUE" x="347.726" y="224.028" size="0.762" layer="96" font="vector" align="bottom-right"/>
-<attribute name="PACKAGE" x="344.17" y="226.568" size="0.508" layer="95" font="vector" align="center"/>
-<attribute name="TOLERANCE" x="348.234" y="224.028" size="0.762" layer="96" font="vector"/>
+<attribute name="NAME" x="347.98" y="226.06" size="1.27" layer="95" align="center"/>
+<attribute name="VALUE" x="347.726" y="224.028" size="0.762" layer="96" align="bottom-right"/>
+<attribute name="PACKAGE" x="344.17" y="226.568" size="0.508" layer="95" align="center"/>
+<attribute name="TOLERANCE" x="348.234" y="224.028" size="0.762" layer="96"/>
 </instance>
 <instance part="R12" gate="G$1" x="347.98" y="210.82" smashed="yes">
-<attribute name="NAME" x="347.98" y="210.82" size="1.27" layer="95" font="vector" align="center"/>
-<attribute name="VALUE" x="347.726" y="208.788" size="0.762" layer="96" font="vector" align="bottom-right"/>
-<attribute name="PACKAGE" x="344.17" y="211.328" size="0.508" layer="95" font="vector" align="center"/>
-<attribute name="TOLERANCE" x="348.234" y="208.788" size="0.762" layer="96" font="vector"/>
+<attribute name="NAME" x="347.98" y="210.82" size="1.27" layer="95" align="center"/>
+<attribute name="VALUE" x="347.726" y="208.788" size="0.762" layer="96" align="bottom-right"/>
+<attribute name="PACKAGE" x="344.17" y="211.328" size="0.508" layer="95" align="center"/>
+<attribute name="TOLERANCE" x="348.234" y="208.788" size="0.762" layer="96"/>
 </instance>
 <instance part="S1" gate="G$1" x="355.6" y="190.5" smashed="yes" rot="R180"/>
 <instance part="C7" gate="G$1" x="175.26" y="231.14" smashed="yes" rot="R90">
-<attribute name="NAME" x="176.149" y="232.41" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="175.006" y="229.87" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="175.768" y="229.108" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="175.006" y="233.426" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="176.149" y="232.41" size="1.27" layer="95" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="175.006" y="229.87" size="0.762" layer="96" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="175.768" y="229.108" size="0.508" layer="97" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="175.006" y="233.426" size="0.762" layer="96" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="C8" gate="G$1" x="180.34" y="231.14" smashed="yes" rot="R90">
-<attribute name="NAME" x="181.229" y="232.41" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="180.086" y="229.87" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="180.848" y="229.108" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="180.086" y="233.426" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="181.229" y="232.41" size="1.27" layer="95" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="180.086" y="229.87" size="0.762" layer="96" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="180.848" y="229.108" size="0.508" layer="97" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="180.086" y="233.426" size="0.762" layer="96" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="C9" gate="G$1" x="185.42" y="231.14" smashed="yes" rot="R90">
-<attribute name="NAME" x="186.309" y="232.41" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="185.166" y="229.87" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="185.928" y="229.108" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="185.166" y="233.426" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="186.309" y="232.41" size="1.27" layer="95" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="185.166" y="229.87" size="0.762" layer="96" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="185.928" y="229.108" size="0.508" layer="97" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="185.166" y="233.426" size="0.762" layer="96" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="C6" gate="G$1" x="170.18" y="231.14" smashed="yes" rot="R90">
-<attribute name="NAME" x="171.069" y="232.41" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="169.926" y="229.87" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="170.688" y="229.108" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="169.926" y="233.426" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="171.069" y="232.41" size="1.27" layer="95" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="169.926" y="229.87" size="0.762" layer="96" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="170.688" y="229.108" size="0.508" layer="97" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="169.926" y="233.426" size="0.762" layer="96" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="GND8" gate="G$1" x="177.8" y="220.98" smashed="yes">
 <attribute name="VALUE" x="177.8" y="219.71" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
@@ -5060,18 +4263,18 @@ when running on discharged 8S battery</text>
 <instance part="GND7" gate="G$1" x="167.64" y="172.72" smashed="yes">
 <attribute name="VALUE" x="167.64" y="171.45" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="PAD43" gate="G$1" x="88.9" y="231.14" smashed="yes">
-<attribute name="NAME" x="88.9" y="232.41" size="1.27" layer="95" font="vector" ratio="15" align="center"/>
+<instance part="PAD43" gate="G$1" x="114.3" y="223.52" smashed="yes">
+<attribute name="NAME" x="114.3" y="224.79" size="1.27" layer="95" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="PAD42" gate="G$1" x="88.9" y="241.3" smashed="yes">
-<attribute name="NAME" x="88.9" y="242.57" size="1.27" layer="95" font="vector" ratio="15" align="center"/>
+<instance part="PAD42" gate="G$1" x="114.3" y="233.68" smashed="yes">
+<attribute name="NAME" x="114.3" y="234.95" size="1.27" layer="95" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="GND2" gate="G$1" x="93.98" y="226.06" smashed="yes">
-<attribute name="VALUE" x="93.98" y="224.79" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
+<instance part="GND2" gate="G$1" x="119.38" y="218.44" smashed="yes">
+<attribute name="VALUE" x="119.38" y="217.17" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="D1" gate="G$1" x="93.98" y="236.22" smashed="yes" rot="R90">
-<attribute name="NAME" x="91.44" y="236.22" size="1.27" layer="95" font="vector" ratio="15" rot="R90" align="center"/>
-<attribute name="MANF#" x="96.52" y="236.22" size="1.016" layer="95" font="vector" ratio="15" rot="R90" align="center"/>
+<instance part="D1" gate="G$1" x="119.38" y="228.6" smashed="yes" rot="R90">
+<attribute name="NAME" x="116.84" y="228.6" size="1.27" layer="95" font="vector" ratio="15" rot="R90" align="center"/>
+<attribute name="MANF#" x="121.92" y="228.6" size="1.016" layer="95" font="vector" ratio="15" rot="R90" align="center"/>
 </instance>
 <instance part="C1" gate="G$1" x="142.24" y="231.14" smashed="yes" rot="R90">
 <attribute name="NAME" x="143.2814" y="232.791" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
@@ -5083,19 +4286,22 @@ when running on discharged 8S battery</text>
 <attribute name="VALUE" x="158.4706" y="229.489" size="1.27" layer="96" font="vector" rot="R270" align="center-left"/>
 <attribute name="PACKAGE" x="156.718" y="229.616" size="0.762" layer="97" font="vector" rot="R90" align="center-right"/>
 </instance>
-<instance part="GND4" gate="G$1" x="149.86" y="220.98" smashed="yes">
-<attribute name="VALUE" x="149.86" y="219.71" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
+<instance part="GND4" gate="G$1" x="149.86" y="223.52" smashed="yes">
+<attribute name="VALUE" x="149.86" y="222.25" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="+P5" gate="G$1" x="149.86" y="238.76" smashed="yes">
-<attribute name="VALUE" x="149.86" y="242.316" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="+P5" gate="G$1" x="149.86" y="236.22" smashed="yes">
+<attribute name="VALUE" x="149.86" y="239.776" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
 <instance part="C2" gate="G$1" x="149.86" y="231.14" smashed="yes" rot="R90">
 <attribute name="NAME" x="150.9014" y="232.791" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
 <attribute name="VALUE" x="150.8506" y="229.489" size="1.27" layer="96" font="vector" rot="R270" align="center-left"/>
 <attribute name="PACKAGE" x="149.098" y="229.616" size="0.762" layer="97" font="vector" rot="R90" align="center-right"/>
 </instance>
-<instance part="+P3" gate="G$1" x="93.98" y="243.84" smashed="yes">
-<attribute name="VALUE" x="93.98" y="247.396" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="CON3" gate="G$1" x="370.84" y="147.32" smashed="yes" rot="MR0">
+<attribute name="NAME" x="368.3" y="156.21" size="1.778" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
+</instance>
+<instance part="+P3" gate="G$1" x="119.38" y="236.22" smashed="yes">
+<attribute name="VALUE" x="119.38" y="239.776" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
 <instance part="+P1" gate="G$1" x="40.64" y="238.76" smashed="yes">
 <attribute name="VALUE" x="40.64" y="242.316" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
@@ -5108,17 +4314,17 @@ when running on discharged 8S battery</text>
 <attribute name="VALUE" x="38.1" y="227.33" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
 <instance part="C4" gate="G$1" x="162.56" y="182.88" smashed="yes" rot="R270">
-<attribute name="NAME" x="161.671" y="181.61" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
-<attribute name="VALUE" x="162.814" y="184.15" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
-<attribute name="PACKAGE" x="162.052" y="184.912" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
-<attribute name="VOLTAGE" x="162.814" y="180.594" size="0.762" layer="96" font="vector" rot="R270" align="bottom-center"/>
+<attribute name="NAME" x="161.671" y="181.61" size="1.27" layer="95" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="162.814" y="184.15" size="0.762" layer="96" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="162.052" y="184.912" size="0.508" layer="97" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="162.814" y="180.594" size="0.762" layer="96" rot="R270" align="bottom-center"/>
 </instance>
-<instance part="J2" gate="G$1" x="335.28" y="144.78" smashed="yes"/>
-<instance part="GND18" gate="G$1" x="340.36" y="139.7" smashed="yes">
-<attribute name="VALUE" x="340.36" y="137.668" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="J2" gate="G$1" x="337.82" y="144.78" smashed="yes"/>
+<instance part="GND18" gate="G$1" x="342.9" y="139.7" smashed="yes">
+<attribute name="VALUE" x="342.9" y="137.668" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="FD2" gate="G$1" x="12.7" y="66.04" smashed="yes" rot="R270"/>
-<instance part="FD1" gate="G$1" x="12.7" y="73.66" smashed="yes" rot="R270"/>
+<instance part="FD2" gate="G$1" x="15.24" y="12.7" smashed="yes" rot="R270"/>
+<instance part="FD1" gate="G$1" x="15.24" y="22.86" smashed="yes" rot="R270"/>
 <instance part="J1" gate="G$1" x="320.04" y="144.78" smashed="yes" rot="MR0"/>
 <instance part="GND13" gate="G$1" x="314.96" y="139.7" smashed="yes">
 <attribute name="VALUE" x="314.96" y="138.43" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
@@ -5138,28 +4344,21 @@ when running on discharged 8S battery</text>
 <instance part="GND6" gate="1" x="162.56" y="172.72" smashed="yes">
 <attribute name="VALUE" x="162.56" y="171.45" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="LED1" gate="G$1" x="226.06" y="114.3" smashed="yes" rot="R270">
-<attribute name="NAME" x="223.52" y="116.84" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
-<attribute name="COLOR" x="226.568" y="118.618" size="0.635" layer="96" font="vector" rot="R270" align="center"/>
+<instance part="LED1" gate="G$1" x="223.52" y="121.92" smashed="yes" rot="R270">
+<attribute name="COLOR" x="223.52" y="121.92" size="1.27" layer="96" font="vector" rot="R270" align="center-left" display="off"/>
+<attribute name="NAME" x="225.298" y="124.46" size="1.27" layer="95" rot="R270"/>
 </instance>
-<instance part="LED3" gate="G$1" x="243.84" y="116.84" smashed="yes" rot="R270">
-<attribute name="NAME" x="260.35" y="111.76" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
-<attribute name="MANF#" x="242.57" y="111.76" size="0.889" layer="97" font="vector" ratio="15" rot="R270" align="center"/>
+<instance part="LED3" gate="G$1" x="241.3" y="121.92" smashed="yes" rot="R270">
+<attribute name="NAME" x="257.556" y="116.84" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
 </instance>
-<instance part="R14" gate="G$1" x="25.4" y="116.84" smashed="yes" rot="MR180">
-<attribute name="NAME" x="25.4" y="116.84" size="1.27" layer="95" font="vector" rot="MR180" align="center"/>
-<attribute name="VALUE" x="25.146" y="118.872" size="0.762" layer="96" font="vector" rot="MR180" align="bottom-right"/>
-<attribute name="PACKAGE" x="21.59" y="116.332" size="0.508" layer="95" font="vector" rot="MR180" align="center"/>
-<attribute name="TOLERANCE" x="25.654" y="118.872" size="0.762" layer="96" font="vector" rot="MR180"/>
+<instance part="R14" gate="G$1" x="33.02" y="116.84" smashed="yes" rot="MR180">
+<attribute name="NAME" x="33.02" y="116.84" size="1.27" layer="95" rot="MR180" align="center"/>
+<attribute name="VALUE" x="32.766" y="118.872" size="0.762" layer="96" rot="MR180" align="bottom-right"/>
+<attribute name="PACKAGE" x="29.21" y="116.332" size="0.508" layer="95" rot="MR180" align="center"/>
+<attribute name="TOLERANCE" x="33.274" y="118.872" size="0.762" layer="96" rot="MR180"/>
 </instance>
-<instance part="GND25" gate="1" x="17.78" y="111.76" smashed="yes">
-<attribute name="VALUE" x="17.78" y="110.49" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
-</instance>
-<instance part="PAD47" gate="G$1" x="370.84" y="149.86" smashed="yes" rot="MR0">
-<attribute name="NAME" x="370.84" y="151.13" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
-</instance>
-<instance part="PAD48" gate="G$1" x="370.84" y="157.48" smashed="yes" rot="MR0">
-<attribute name="NAME" x="370.84" y="158.75" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
+<instance part="GND25" gate="1" x="22.86" y="111.76" smashed="yes">
+<attribute name="VALUE" x="22.86" y="110.49" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
 </instances>
 <busses>
@@ -5168,81 +4367,81 @@ when running on discharged 8S battery</text>
 <net name="CAN2_TX" class="0">
 <segment>
 <wire x1="45.72" y1="154.94" x2="40.64" y2="154.94" width="0.1524" layer="91"/>
-<label x="40.64" y="154.94" size="1.27" layer="95" font="vector" rot="MR0" xref="yes"/>
+<label x="40.64" y="154.94" size="1.27" layer="95" rot="MR0" xref="yes"/>
 <pinref part="PAD3" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="CAN2_RX" class="0">
 <segment>
 <wire x1="45.72" y1="152.4" x2="40.64" y2="152.4" width="0.1524" layer="91"/>
-<label x="40.64" y="152.4" size="1.27" layer="95" font="vector" rot="MR0" xref="yes"/>
+<label x="40.64" y="152.4" size="1.27" layer="95" rot="MR0" xref="yes"/>
 <pinref part="PAD4" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="CAN1_TX" class="0">
 <segment>
 <wire x1="45.72" y1="160.02" x2="40.64" y2="160.02" width="0.1524" layer="91"/>
-<label x="40.64" y="160.02" size="1.27" layer="95" font="vector" rot="MR0" xref="yes"/>
+<label x="40.64" y="160.02" size="1.27" layer="95" rot="MR0" xref="yes"/>
 <pinref part="PAD1" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <wire x1="320.04" y1="127" x2="317.5" y2="127" width="0.1524" layer="91"/>
 <wire x1="317.5" y1="127" x2="312.42" y2="127" width="0.1524" layer="91"/>
-<label x="312.42" y="127" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="312.42" y="127" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="IC3" gate="G$1" pin="TXD"/>
 </segment>
 </net>
 <net name="RGB_LED_R" class="0">
 <segment>
 <wire x1="45.72" y1="119.38" x2="43.18" y2="119.38" width="0.1524" layer="91"/>
-<label x="43.18" y="119.38" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="119.38" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD12" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R7" gate="G$1" pin="2"/>
-<wire x1="279.4" y1="78.74" x2="279.4" y2="83.82" width="0.1524" layer="91"/>
-<label x="279.4" y="78.74" size="1.27" layer="95" font="vector" rot="R270" xref="yes"/>
+<wire x1="276.86" y1="83.82" x2="276.86" y2="88.9" width="0.1524" layer="91"/>
+<label x="276.86" y="83.82" size="1.27" layer="95" rot="R270" xref="yes"/>
 </segment>
 </net>
 <net name="RGB_LED_G" class="0">
 <segment>
 <wire x1="45.72" y1="121.92" x2="43.18" y2="121.92" width="0.1524" layer="91"/>
-<label x="43.18" y="121.92" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="121.92" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD11" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R6" gate="G$1" pin="2"/>
-<wire x1="274.32" y1="83.82" x2="274.32" y2="78.74" width="0.1524" layer="91"/>
-<label x="274.32" y="78.74" size="1.27" layer="95" font="vector" rot="R270" xref="yes"/>
+<wire x1="271.78" y1="88.9" x2="271.78" y2="83.82" width="0.1524" layer="91"/>
+<label x="271.78" y="83.82" size="1.27" layer="95" rot="R270" xref="yes"/>
 </segment>
 </net>
 <net name="RGB_LED_B" class="0">
 <segment>
 <wire x1="45.72" y1="124.46" x2="43.18" y2="124.46" width="0.1524" layer="91"/>
-<label x="43.18" y="124.46" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="124.46" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD10" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R5" gate="G$1" pin="2"/>
-<wire x1="269.24" y1="83.82" x2="269.24" y2="78.74" width="0.1524" layer="91"/>
-<label x="269.24" y="78.74" size="1.27" layer="95" font="vector" rot="R270" xref="yes"/>
+<wire x1="266.7" y1="88.9" x2="266.7" y2="83.82" width="0.1524" layer="91"/>
+<label x="266.7" y="83.82" size="1.27" layer="95" rot="R270" xref="yes"/>
 </segment>
 </net>
 <net name="GPIO1" class="0">
 <segment>
 <wire x1="45.72" y1="114.3" x2="43.18" y2="114.3" width="0.1524" layer="91"/>
-<label x="43.18" y="114.3" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="114.3" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD14" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
-<pinref part="PAD48" gate="G$1" pin="P$1"/>
-<wire x1="368.3" y1="157.48" x2="365.76" y2="157.48" width="0.1524" layer="91"/>
-<label x="365.76" y="157.48" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" xref="yes"/>
+<pinref part="CON3" gate="G$1" pin="2"/>
+<wire x1="363.22" y1="152.4" x2="360.68" y2="152.4" width="0.1524" layer="91"/>
+<label x="360.68" y="152.4" size="1.27" layer="95" rot="MR0" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A_GND" class="0">
 <segment>
-<label x="45.72" y="213.36" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="213.36" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="48.26" y1="213.36" x2="45.72" y2="213.36" width="0.1524" layer="91"/>
 <pinref part="PAD28" gate="G$1" pin="P$1"/>
 </segment>
@@ -5253,12 +4452,12 @@ when running on discharged 8S battery</text>
 <junction x="236.22" y="198.12"/>
 <pinref part="R4" gate="G$1" pin="1"/>
 <pinref part="Q1" gate="T2" pin="S"/>
-<label x="218.44" y="198.12" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="218.44" y="198.12" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B" class="1">
 <segment>
-<label x="45.72" y="208.28" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="208.28" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="208.28" x2="48.26" y2="208.28" width="0.1524" layer="91"/>
 <pinref part="PAD30" gate="G$1" pin="P$1"/>
 </segment>
@@ -5271,12 +4470,12 @@ when running on discharged 8S battery</text>
 <junction x="302.26" y="218.44"/>
 <pinref part="PAD45" gate="G$1" pin="P$1"/>
 <wire x1="302.26" y1="218.44" x2="304.8" y2="218.44" width="0.1524" layer="91"/>
-<label x="279.4" y="218.44" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="279.4" y="218.44" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B_GND" class="0">
 <segment>
-<label x="45.72" y="203.2" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="203.2" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="203.2" x2="48.26" y2="203.2" width="0.1524" layer="91"/>
 <pinref part="PAD32" gate="G$1" pin="P$1"/>
 </segment>
@@ -5287,24 +4486,24 @@ when running on discharged 8S battery</text>
 <pinref part="Q2" gate="T2" pin="S"/>
 <wire x1="302.26" y1="205.74" x2="302.26" y2="195.58" width="0.1524" layer="91"/>
 <junction x="302.26" y="195.58"/>
-<label x="279.4" y="195.58" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="279.4" y="195.58" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A_GATE_HIGH" class="1">
 <segment>
-<label x="45.72" y="220.98" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="220.98" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="220.98" x2="48.26" y2="220.98" width="0.1524" layer="91"/>
 <pinref part="PAD25" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R1" gate="G$1" pin="1"/>
 <wire x1="213.36" y1="228.6" x2="215.9" y2="228.6" width="0.1524" layer="91"/>
-<label x="213.36" y="228.6" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="213.36" y="228.6" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A" class="1">
 <segment>
-<label x="45.72" y="218.44" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="218.44" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="218.44" x2="48.26" y2="218.44" width="0.1524" layer="91"/>
 <pinref part="PAD26" gate="G$1" pin="P$1"/>
 </segment>
@@ -5317,74 +4516,74 @@ when running on discharged 8S battery</text>
 <wire x1="236.22" y1="220.98" x2="213.36" y2="220.98" width="0.1524" layer="91"/>
 <pinref part="Q1" gate="T2" pin="D"/>
 <pinref part="Q1" gate="T1" pin="S"/>
-<label x="213.36" y="220.98" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="213.36" y="220.98" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B_GATE_HIGH" class="1">
 <segment>
-<label x="45.72" y="210.82" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="210.82" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="210.82" x2="48.26" y2="210.82" width="0.1524" layer="91"/>
 <pinref part="PAD29" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R8" gate="G$1" pin="1"/>
 <wire x1="281.94" y1="226.06" x2="279.4" y2="226.06" width="0.1524" layer="91"/>
-<label x="279.4" y="226.06" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="279.4" y="226.06" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B_GATE_LOW" class="0">
 <segment>
-<label x="45.72" y="205.74" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="205.74" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="205.74" x2="48.26" y2="205.74" width="0.1524" layer="91"/>
 <pinref part="PAD31" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R9" gate="G$1" pin="1"/>
 <wire x1="281.94" y1="210.82" x2="279.4" y2="210.82" width="0.1524" layer="91"/>
-<label x="279.4" y="210.82" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="279.4" y="210.82" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A_GATE_LOW" class="0">
 <segment>
-<label x="45.72" y="215.9" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="215.9" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="215.9" x2="48.26" y2="215.9" width="0.1524" layer="91"/>
 <pinref part="PAD27" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R2" gate="G$1" pin="1"/>
 <wire x1="213.36" y1="213.36" x2="215.9" y2="213.36" width="0.1524" layer="91"/>
-<label x="213.36" y="213.36" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="213.36" y="213.36" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B_CURRENT_SHUNT_N" class="0">
 <segment>
 <wire x1="48.26" y1="177.8" x2="45.72" y2="177.8" width="0.1524" layer="91"/>
-<label x="45.72" y="177.8" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="177.8" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD39" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R10" gate="G$1" pin="S1"/>
 <wire x1="289.56" y1="190.5" x2="299.72" y2="190.5" width="0.1524" layer="91"/>
 <wire x1="299.72" y1="190.5" x2="299.72" y2="187.96" width="0.1524" layer="91"/>
-<label x="289.56" y="190.5" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="289.56" y="190.5" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B_CURRENT_SHUNT_P" class="0">
 <segment>
 <wire x1="48.26" y1="175.26" x2="45.72" y2="175.26" width="0.1524" layer="91"/>
-<label x="45.72" y="175.26" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="175.26" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD40" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <wire x1="289.56" y1="175.26" x2="299.72" y2="175.26" width="0.1524" layer="91"/>
 <pinref part="R10" gate="G$1" pin="S2"/>
 <wire x1="299.72" y1="177.8" x2="299.72" y2="175.26" width="0.1524" layer="91"/>
-<label x="289.56" y="175.26" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="289.56" y="175.26" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A_CURRENT_SHUNT_N" class="0">
 <segment>
-<label x="45.72" y="190.5" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="190.5" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="190.5" x2="48.26" y2="190.5" width="0.1524" layer="91"/>
 <pinref part="PAD37" gate="G$1" pin="P$1"/>
 </segment>
@@ -5392,12 +4591,12 @@ when running on discharged 8S battery</text>
 <pinref part="R4" gate="G$1" pin="S1"/>
 <wire x1="223.52" y1="193.04" x2="233.68" y2="193.04" width="0.1524" layer="91"/>
 <wire x1="233.68" y1="193.04" x2="233.68" y2="190.5" width="0.1524" layer="91"/>
-<label x="223.52" y="193.04" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="223.52" y="193.04" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A_CURRENT_SHUNT_P" class="0">
 <segment>
-<label x="45.72" y="187.96" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="187.96" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="187.96" x2="48.26" y2="187.96" width="0.1524" layer="91"/>
 <pinref part="PAD38" gate="G$1" pin="P$1"/>
 </segment>
@@ -5405,32 +4604,32 @@ when running on discharged 8S battery</text>
 <wire x1="223.52" y1="177.8" x2="233.68" y2="177.8" width="0.1524" layer="91"/>
 <pinref part="R4" gate="G$1" pin="S2"/>
 <wire x1="233.68" y1="180.34" x2="233.68" y2="177.8" width="0.1524" layer="91"/>
-<label x="223.52" y="177.8" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="223.52" y="177.8" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="USART_TX" class="0">
 <segment>
 <wire x1="45.72" y1="93.98" x2="43.18" y2="93.98" width="0.1524" layer="91"/>
-<label x="43.18" y="93.98" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="93.98" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD19" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="USART_RX" class="0">
 <segment>
 <wire x1="45.72" y1="91.44" x2="43.18" y2="91.44" width="0.1524" layer="91"/>
-<label x="43.18" y="91.44" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="91.44" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD20" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="CAN1_RX" class="0">
 <segment>
 <wire x1="45.72" y1="157.48" x2="40.64" y2="157.48" width="0.1524" layer="91"/>
-<label x="40.64" y="157.48" size="1.27" layer="95" font="vector" rot="MR0" xref="yes"/>
+<label x="40.64" y="157.48" size="1.27" layer="95" rot="MR0" xref="yes"/>
 <pinref part="PAD2" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <wire x1="320.04" y1="119.38" x2="312.42" y2="119.38" width="0.1524" layer="91"/>
-<label x="312.42" y="119.38" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="312.42" y="119.38" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="IC3" gate="G$1" pin="RXD"/>
 </segment>
 </net>
@@ -5445,7 +4644,7 @@ when running on discharged 8S battery</text>
 <pinref part="C10" gate="G$1" pin="1"/>
 <wire x1="320.04" y1="121.92" x2="314.96" y2="121.92" width="0.1524" layer="91"/>
 <wire x1="314.96" y1="121.92" x2="299.72" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="299.72" y1="121.92" x2="299.72" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="299.72" y1="121.92" x2="299.72" y2="119.38" width="0.1524" layer="91"/>
 <wire x1="299.72" y1="121.92" x2="299.72" y2="124.46" width="0.1524" layer="91"/>
 <junction x="299.72" y="121.92"/>
 <pinref part="+P12" gate="G$1" pin="VDD_5V"/>
@@ -5469,22 +4668,22 @@ when running on discharged 8S battery</text>
 <segment>
 <pinref part="LED4" gate="G$1" pin="A"/>
 <pinref part="+P11" gate="G$1" pin="VDD_5V"/>
-<wire x1="274.32" y1="119.38" x2="274.32" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="271.78" y1="124.46" x2="271.78" y2="127" width="0.1524" layer="91"/>
 <pinref part="LED3" gate="G$1" pin="A"/>
-<wire x1="274.32" y1="121.92" x2="274.32" y2="127" width="0.1524" layer="91"/>
-<wire x1="251.46" y1="119.38" x2="251.46" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="251.46" y1="121.92" x2="274.32" y2="121.92" width="0.1524" layer="91"/>
-<junction x="274.32" y="121.92"/>
+<wire x1="271.78" y1="127" x2="271.78" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="248.92" y1="124.46" x2="248.92" y2="127" width="0.1524" layer="91"/>
+<wire x1="248.92" y1="127" x2="271.78" y2="127" width="0.1524" layer="91"/>
+<junction x="271.78" y="127"/>
 </segment>
 <segment>
 <pinref part="+P9" gate="G$1" pin="VDD_5V"/>
 <pinref part="LED2" gate="G$1" pin="A"/>
+<wire x1="231.14" y1="124.46" x2="231.14" y2="127" width="0.1524" layer="91"/>
 <pinref part="LED1" gate="G$1" pin="A"/>
-<wire x1="233.68" y1="119.38" x2="233.68" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="233.68" y1="121.92" x2="233.68" y2="127" width="0.1524" layer="91"/>
-<wire x1="226.06" y1="119.38" x2="226.06" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="226.06" y1="121.92" x2="233.68" y2="121.92" width="0.1524" layer="91"/>
-<junction x="233.68" y="121.92"/>
+<wire x1="231.14" y1="127" x2="231.14" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="223.52" y1="124.46" x2="223.52" y2="127" width="0.1524" layer="91"/>
+<wire x1="223.52" y1="127" x2="231.14" y2="127" width="0.1524" layer="91"/>
+<junction x="231.14" y="127"/>
 </segment>
 <segment>
 <pinref part="IC1" gate="G$1" pin="VCC"/>
@@ -5499,53 +4698,54 @@ when running on discharged 8S battery</text>
 <net name="CAN1_LED" class="0">
 <segment>
 <wire x1="45.72" y1="134.62" x2="43.18" y2="134.62" width="0.1524" layer="91"/>
-<label x="43.18" y="134.62" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="134.62" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD6" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R3" gate="G$1" pin="1"/>
-<wire x1="233.68" y1="93.98" x2="233.68" y2="96.52" width="0.1524" layer="91"/>
-<label x="233.68" y="93.98" size="1.27" layer="95" font="vector" rot="R270" xref="yes"/>
+<wire x1="231.14" y1="99.06" x2="231.14" y2="101.6" width="0.1524" layer="91"/>
+<label x="231.14" y="99.06" size="1.27" layer="95" rot="R270" xref="yes"/>
 </segment>
 </net>
 <net name="CAN2_LED" class="0">
 <segment>
 <wire x1="45.72" y1="137.16" x2="43.18" y2="137.16" width="0.1524" layer="91"/>
-<label x="43.18" y="137.16" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="137.16" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD5" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="OVERCURRENT_PROTECT_ADJ" class="0">
 <segment>
+<wire x1="45.72" y1="116.84" x2="43.18" y2="116.84" width="0.1524" layer="91"/>
 <pinref part="PAD13" gate="G$1" pin="P$1"/>
-<wire x1="45.72" y1="116.84" x2="30.48" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="116.84" x2="38.1" y2="116.84" width="0.1524" layer="91"/>
 <pinref part="R14" gate="G$1" pin="2"/>
 </segment>
 </net>
 <net name="USB+" class="0">
 <segment>
 <wire x1="45.72" y1="132.08" x2="43.18" y2="132.08" width="0.1524" layer="91"/>
-<label x="43.18" y="132.08" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="132.08" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD7" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="USB-" class="0">
 <segment>
 <wire x1="45.72" y1="129.54" x2="43.18" y2="129.54" width="0.1524" layer="91"/>
-<label x="43.18" y="129.54" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="129.54" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD8" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="USB_VBUS" class="0">
 <segment>
 <wire x1="45.72" y1="127" x2="43.18" y2="127" width="0.1524" layer="91"/>
-<label x="43.18" y="127" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="127" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD9" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="POWER_ENABLE_IN" class="0">
 <segment>
-<label x="43.18" y="96.52" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="96.52" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="96.52" x2="43.18" y2="96.52" width="0.1524" layer="91"/>
 <pinref part="PAD18" gate="G$1" pin="P$1"/>
 </segment>
@@ -5553,39 +4753,39 @@ when running on discharged 8S battery</text>
 <net name="GPIO2" class="0">
 <segment>
 <wire x1="45.72" y1="111.76" x2="43.18" y2="111.76" width="0.1524" layer="91"/>
-<label x="43.18" y="111.76" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="111.76" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD15" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="EN_GATE_OUT" class="0">
 <segment>
 <wire x1="43.18" y1="109.22" x2="45.72" y2="109.22" width="0.1524" layer="91"/>
-<label x="43.18" y="109.22" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="109.22" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD16" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="GAIN_OUT" class="0">
 <segment>
 <wire x1="43.18" y1="106.68" x2="45.72" y2="106.68" width="0.1524" layer="91"/>
-<label x="43.18" y="106.68" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="106.68" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD17" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="BEC_ENABLE_OUT" class="0">
 <segment>
 <wire x1="45.72" y1="88.9" x2="43.18" y2="88.9" width="0.1524" layer="91"/>
-<label x="43.18" y="88.9" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="43.18" y="88.9" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD21" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="IC2" gate="G$1" pin="EN"/>
 <wire x1="314.96" y1="91.44" x2="312.42" y2="91.44" width="0.1524" layer="91"/>
-<label x="312.42" y="91.44" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="312.42" y="91.44" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_C_GND" class="0">
 <segment>
-<label x="45.72" y="193.04" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="193.04" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="193.04" x2="48.26" y2="193.04" width="0.1524" layer="91"/>
 <pinref part="PAD36" gate="G$1" pin="P$1"/>
 </segment>
@@ -5593,24 +4793,24 @@ when running on discharged 8S battery</text>
 <pinref part="S1" gate="G$1" pin="IN"/>
 <wire x1="355.6" y1="195.58" x2="355.6" y2="193.04" width="0.1524" layer="91"/>
 <wire x1="355.6" y1="195.58" x2="342.9" y2="195.58" width="0.1524" layer="91"/>
-<label x="342.9" y="195.58" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="342.9" y="195.58" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_C_GATE_LOW" class="0">
 <segment>
-<label x="45.72" y="195.58" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="195.58" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="195.58" x2="48.26" y2="195.58" width="0.1524" layer="91"/>
 <pinref part="PAD35" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R12" gate="G$1" pin="1"/>
 <wire x1="342.9" y1="210.82" x2="340.36" y2="210.82" width="0.1524" layer="91"/>
-<label x="340.36" y="210.82" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="340.36" y="210.82" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_C" class="1">
 <segment>
-<label x="45.72" y="198.12" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="198.12" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="198.12" x2="48.26" y2="198.12" width="0.1524" layer="91"/>
 <pinref part="PAD34" gate="G$1" pin="P$1"/>
 </segment>
@@ -5623,19 +4823,19 @@ when running on discharged 8S battery</text>
 <junction x="363.22" y="218.44"/>
 <pinref part="Q3" gate="T1" pin="S"/>
 <wire x1="363.22" y1="220.98" x2="363.22" y2="218.44" width="0.1524" layer="91"/>
-<label x="340.36" y="218.44" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="340.36" y="218.44" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_C_GATE_HIGH" class="1">
 <segment>
-<label x="45.72" y="200.66" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="200.66" size="1.27" layer="95" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="200.66" x2="48.26" y2="200.66" width="0.1524" layer="91"/>
 <pinref part="PAD33" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R11" gate="G$1" pin="1"/>
 <wire x1="342.9" y1="226.06" x2="340.36" y2="226.06" width="0.1524" layer="91"/>
-<label x="340.36" y="226.06" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="340.36" y="226.06" size="1.27" layer="95" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="GND" class="0">
@@ -5650,6 +4850,7 @@ when running on discharged 8S battery</text>
 <pinref part="GND15" gate="1" pin="GND"/>
 <wire x1="327.66" y1="144.78" x2="327.66" y2="142.24" width="0.1524" layer="91"/>
 <pinref part="J2" gate="G$1" pin="P$1"/>
+<wire x1="332.74" y1="144.78" x2="335.28" y2="144.78" width="0.1524" layer="91"/>
 <wire x1="332.74" y1="144.78" x2="327.66" y2="144.78" width="0.1524" layer="91"/>
 <junction x="327.66" y="144.78"/>
 </segment>
@@ -5658,11 +4859,13 @@ when running on discharged 8S battery</text>
 <wire x1="317.5" y1="124.46" x2="317.5" y2="106.68" width="0.1524" layer="91"/>
 <pinref part="IC3" gate="G$1" pin="GND"/>
 <pinref part="C10" gate="G$1" pin="2"/>
-<wire x1="299.72" y1="111.76" x2="299.72" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="317.5" y1="106.68" x2="317.5" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="299.72" y1="109.22" x2="299.72" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="299.72" y1="109.22" x2="299.72" y2="106.68" width="0.1524" layer="91"/>
 <wire x1="299.72" y1="106.68" x2="317.5" y2="106.68" width="0.1524" layer="91"/>
 <junction x="317.5" y="106.68"/>
 <pinref part="GND14" gate="1" pin="GND"/>
-<wire x1="317.5" y1="101.6" x2="317.5" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="317.5" y1="101.6" x2="317.5" y2="104.14" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="C11" gate="G$1" pin="2"/>
@@ -5671,9 +4874,9 @@ when running on discharged 8S battery</text>
 </segment>
 <segment>
 <wire x1="360.68" y1="147.32" x2="360.68" y2="149.86" width="0.1524" layer="91"/>
-<wire x1="360.68" y1="149.86" x2="368.3" y2="149.86" width="0.1524" layer="91"/>
+<pinref part="CON3" gate="G$1" pin="1"/>
+<wire x1="360.68" y1="149.86" x2="363.22" y2="149.86" width="0.1524" layer="91"/>
 <pinref part="GND21" gate="1" pin="GND"/>
-<pinref part="PAD47" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="C4" gate="G$1" pin="2"/>
@@ -5682,16 +4885,10 @@ when running on discharged 8S battery</text>
 <wire x1="162.56" y1="175.26" x2="162.56" y2="177.8" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<wire x1="17.78" y1="114.3" x2="17.78" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="17.78" y1="116.84" x2="20.32" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="22.86" y1="114.3" x2="22.86" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="22.86" y1="116.84" x2="27.94" y2="116.84" width="0.1524" layer="91"/>
 <pinref part="R14" gate="G$1" pin="1"/>
 <pinref part="GND25" gate="1" pin="GND"/>
-</segment>
-<segment>
-<wire x1="342.9" y1="127" x2="350.52" y2="127" width="0.1524" layer="91"/>
-<pinref part="IC3" gate="G$1" pin="S"/>
-<pinref part="GND20" gate="1" pin="GND"/>
-<wire x1="350.52" y1="127" x2="350.52" y2="116.84" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="GNDD" class="0">
@@ -5733,9 +4930,9 @@ when running on discharged 8S battery</text>
 </segment>
 <segment>
 <pinref part="GND18" gate="G$1" pin="GNDD"/>
-<wire x1="340.36" y1="142.24" x2="340.36" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="342.9" y1="142.24" x2="342.9" y2="144.78" width="0.1524" layer="91"/>
 <pinref part="J2" gate="G$1" pin="P$2"/>
-<wire x1="340.36" y1="144.78" x2="337.82" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="342.9" y1="144.78" x2="340.36" y2="144.78" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="CAN1_VDD" class="0">
@@ -5769,25 +4966,25 @@ when running on discharged 8S battery</text>
 <net name="N$58" class="0">
 <segment>
 <pinref part="LED4" gate="G$1" pin="R"/>
-<wire x1="279.4" y1="104.14" x2="279.4" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="276.86" y1="109.22" x2="276.86" y2="106.68" width="0.1524" layer="91"/>
 <pinref part="R7" gate="G$1" pin="1"/>
 <pinref part="LED3" gate="G$1" pin="R"/>
-<wire x1="279.4" y1="101.6" x2="279.4" y2="93.98" width="0.1524" layer="91"/>
-<wire x1="256.54" y1="104.14" x2="256.54" y2="101.6" width="0.1524" layer="91"/>
-<wire x1="256.54" y1="101.6" x2="279.4" y2="101.6" width="0.1524" layer="91"/>
-<junction x="279.4" y="101.6"/>
+<wire x1="276.86" y1="106.68" x2="276.86" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="254" y1="109.22" x2="254" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="254" y1="106.68" x2="276.86" y2="106.68" width="0.1524" layer="91"/>
+<junction x="276.86" y="106.68"/>
 </segment>
 </net>
 <net name="N$60" class="0">
 <segment>
 <pinref part="LED4" gate="G$1" pin="B"/>
-<wire x1="269.24" y1="104.14" x2="269.24" y2="96.52" width="0.1524" layer="91"/>
+<wire x1="266.7" y1="109.22" x2="266.7" y2="101.6" width="0.1524" layer="91"/>
 <pinref part="R5" gate="G$1" pin="1"/>
 <pinref part="LED3" gate="G$1" pin="B"/>
-<wire x1="269.24" y1="96.52" x2="269.24" y2="93.98" width="0.1524" layer="91"/>
-<wire x1="246.38" y1="104.14" x2="246.38" y2="96.52" width="0.1524" layer="91"/>
-<wire x1="246.38" y1="96.52" x2="269.24" y2="96.52" width="0.1524" layer="91"/>
-<junction x="269.24" y="96.52"/>
+<wire x1="266.7" y1="101.6" x2="266.7" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="243.84" y1="109.22" x2="243.84" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="243.84" y1="101.6" x2="266.7" y2="101.6" width="0.1524" layer="91"/>
+<junction x="266.7" y="101.6"/>
 </segment>
 </net>
 <net name="TEMPERATURE_SENSOR" class="0">
@@ -5795,26 +4992,26 @@ when running on discharged 8S battery</text>
 <pinref part="IC1" gate="G$1" pin="OUT"/>
 <wire x1="175.26" y1="187.96" x2="162.56" y2="187.96" width="0.1524" layer="91"/>
 <wire x1="160.02" y1="187.96" x2="162.56" y2="187.96" width="0.1524" layer="91"/>
-<label x="160.02" y="187.96" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="160.02" y="187.96" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="C4" gate="G$1" pin="1"/>
 <wire x1="162.56" y1="185.42" x2="162.56" y2="187.96" width="0.1524" layer="91"/>
 <junction x="162.56" y="187.96"/>
 </segment>
 <segment>
 <wire x1="48.26" y1="172.72" x2="45.72" y2="172.72" width="0.1524" layer="91"/>
-<label x="45.72" y="172.72" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="45.72" y="172.72" size="1.27" layer="95" rot="R180" xref="yes"/>
 <pinref part="PAD41" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="PGND" class="0">
 <segment>
 <pinref part="GND3" gate="G$1" pin="PGND"/>
-<wire x1="142.24" y1="223.52" x2="142.24" y2="228.6" width="0.1524" layer="91"/>
+<wire x1="142.24" y1="226.06" x2="142.24" y2="228.6" width="0.1524" layer="91"/>
 <pinref part="C1" gate="G$1" pin="-"/>
 </segment>
 <segment>
 <pinref part="GND5" gate="G$1" pin="PGND"/>
-<wire x1="157.48" y1="223.52" x2="157.48" y2="228.6" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="226.06" x2="157.48" y2="228.6" width="0.1524" layer="91"/>
 <pinref part="C3" gate="G$1" pin="-"/>
 </segment>
 <segment>
@@ -5849,17 +5046,17 @@ when running on discharged 8S battery</text>
 </segment>
 <segment>
 <pinref part="D1" gate="G$1" pin="A"/>
-<wire x1="93.98" y1="231.14" x2="91.44" y2="231.14" width="0.1524" layer="91"/>
+<wire x1="119.38" y1="223.52" x2="116.84" y2="223.52" width="0.1524" layer="91"/>
 <pinref part="GND2" gate="G$1" pin="PGND"/>
-<wire x1="93.98" y1="228.6" x2="93.98" y2="231.14" width="0.1524" layer="91"/>
-<junction x="93.98" y="231.14"/>
-<junction x="93.98" y="231.14"/>
-<wire x1="93.98" y1="231.14" x2="93.98" y2="233.68" width="0.1524" layer="91"/>
+<wire x1="119.38" y1="220.98" x2="119.38" y2="223.52" width="0.1524" layer="91"/>
+<junction x="119.38" y="223.52"/>
+<junction x="119.38" y="223.52"/>
+<wire x1="119.38" y1="223.52" x2="119.38" y2="226.06" width="0.1524" layer="91"/>
 <pinref part="PAD43" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="GND4" gate="G$1" pin="PGND"/>
-<wire x1="149.86" y1="223.52" x2="149.86" y2="228.6" width="0.1524" layer="91"/>
+<wire x1="149.86" y1="226.06" x2="149.86" y2="228.6" width="0.1524" layer="91"/>
 <pinref part="C2" gate="G$1" pin="-"/>
 </segment>
 <segment>
@@ -5897,12 +5094,12 @@ when running on discharged 8S battery</text>
 </net>
 <net name="VDC" class="1">
 <segment>
-<wire x1="157.48" y1="238.76" x2="157.48" y2="233.68" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="236.22" x2="157.48" y2="233.68" width="0.1524" layer="91"/>
 <pinref part="+P6" gate="G$1" pin="VDC"/>
 <pinref part="C3" gate="G$1" pin="+"/>
 </segment>
 <segment>
-<wire x1="142.24" y1="238.76" x2="142.24" y2="233.68" width="0.1524" layer="91"/>
+<wire x1="142.24" y1="236.22" x2="142.24" y2="233.68" width="0.1524" layer="91"/>
 <pinref part="+P4" gate="G$1" pin="VDC"/>
 <pinref part="C1" gate="G$1" pin="+"/>
 </segment>
@@ -5941,19 +5138,19 @@ when running on discharged 8S battery</text>
 <wire x1="302.26" y1="231.14" x2="302.26" y2="233.68" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<wire x1="149.86" y1="238.76" x2="149.86" y2="233.68" width="0.1524" layer="91"/>
+<wire x1="149.86" y1="236.22" x2="149.86" y2="233.68" width="0.1524" layer="91"/>
 <pinref part="+P5" gate="G$1" pin="VDC"/>
 <pinref part="C2" gate="G$1" pin="+"/>
 </segment>
 <segment>
 <pinref part="D1" gate="G$1" pin="C"/>
-<wire x1="91.44" y1="241.3" x2="93.98" y2="241.3" width="0.1524" layer="91"/>
-<junction x="93.98" y="241.3"/>
-<junction x="93.98" y="241.3"/>
-<wire x1="93.98" y1="241.3" x2="93.98" y2="238.76" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="233.68" x2="119.38" y2="233.68" width="0.1524" layer="91"/>
+<junction x="119.38" y="233.68"/>
+<junction x="119.38" y="233.68"/>
+<wire x1="119.38" y1="233.68" x2="119.38" y2="231.14" width="0.1524" layer="91"/>
 <pinref part="PAD42" gate="G$1" pin="P$1"/>
 <pinref part="+P3" gate="G$1" pin="VDC"/>
-<wire x1="93.98" y1="243.84" x2="93.98" y2="241.3" width="0.1524" layer="91"/>
+<wire x1="119.38" y1="236.22" x2="119.38" y2="233.68" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <wire x1="48.26" y1="231.14" x2="40.64" y2="231.14" width="0.1524" layer="91"/>
@@ -5966,12 +5163,12 @@ when running on discharged 8S battery</text>
 <segment>
 <pinref part="R3" gate="G$1" pin="2"/>
 <pinref part="LED2" gate="G$1" pin="C"/>
-<wire x1="233.68" y1="106.68" x2="233.68" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="231.14" y1="111.76" x2="231.14" y2="114.3" width="0.1524" layer="91"/>
 <pinref part="LED1" gate="G$1" pin="C"/>
-<wire x1="233.68" y1="109.22" x2="233.68" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="226.06" y1="111.76" x2="226.06" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="226.06" y1="109.22" x2="233.68" y2="109.22" width="0.1524" layer="91"/>
-<junction x="233.68" y="109.22"/>
+<wire x1="231.14" y1="114.3" x2="231.14" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="223.52" y1="116.84" x2="223.52" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="223.52" y1="114.3" x2="231.14" y2="114.3" width="0.1524" layer="91"/>
+<junction x="231.14" y="114.3"/>
 </segment>
 </net>
 <net name="N$22" class="0">
@@ -6044,61 +5241,40 @@ when running on discharged 8S battery</text>
 <wire x1="292.1" y1="210.82" x2="294.64" y2="210.82" width="0.1524" layer="91"/>
 </segment>
 </net>
+<net name="N$2" class="0">
+<segment>
+<wire x1="342.9" y1="127" x2="350.52" y2="127" width="0.1524" layer="91"/>
+<pinref part="GND20" gate="1" pin="GND"/>
+<wire x1="350.52" y1="127" x2="350.52" y2="116.84" width="0.1524" layer="91"/>
+<pinref part="IC3" gate="G$1" pin="S"/>
+</segment>
+</net>
 <net name="N$4" class="0">
 <segment>
 <pinref part="LED3" gate="G$1" pin="G"/>
-<wire x1="251.46" y1="104.14" x2="251.46" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="248.92" y1="106.68" x2="248.92" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="248.92" y1="106.68" x2="248.92" y2="104.14" width="0.1524" layer="91"/>
 <pinref part="LED4" gate="G$1" pin="G"/>
-<wire x1="274.32" y1="104.14" x2="274.32" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="271.78" y1="109.22" x2="271.78" y2="104.14" width="0.1524" layer="91"/>
 <pinref part="R6" gate="G$1" pin="1"/>
-<wire x1="274.32" y1="99.06" x2="274.32" y2="93.98" width="0.1524" layer="91"/>
-<wire x1="251.46" y1="99.06" x2="274.32" y2="99.06" width="0.1524" layer="91"/>
-<junction x="274.32" y="99.06"/>
+<wire x1="271.78" y1="104.14" x2="271.78" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="248.92" y1="104.14" x2="271.78" y2="104.14" width="0.1524" layer="91"/>
+<junction x="271.78" y="104.14"/>
 </segment>
 </net>
 </nets>
 </sheet>
-<sheet>
-<description>changelog</description>
-<plain>
-<text x="7.62" y="124.46" size="1.778" layer="97" font="vector" align="top-left">-Current shunts replaced (5 mOhms replaced with 10 mOhms)-
--Overcurrent protection added. Itrip is ~35 A
--RCPWM th connector replaced with smd solder pads
--Some design notes added to the schematic
--TVS diode (D1) replaced with one that has lower breaksdown voltage</text>
-</plain>
-<instances>
-<instance part="FRAME2" gate="G$1" x="0" y="0" smashed="yes">
-<attribute name="DRAWING_NAME" x="140.97" y="15.24" size="2.54" layer="94"/>
-<attribute name="LAST_DATE_TIME" x="140.97" y="10.16" size="2.286" layer="94"/>
-<attribute name="SHEET" x="154.305" y="5.08" size="2.54" layer="94"/>
-</instance>
-</instances>
-<busses>
-</busses>
-<nets>
-</nets>
-</sheet>
 </sheets>
 <errors>
-<approved hash="106,1,45.72,137.16,CAN2_LED,,,,,"/>
-<approved hash="106,1,45.72,152.4,CAN2_RX,,,,,"/>
-<approved hash="106,1,45.72,154.94,CAN2_TX,,,,,"/>
-<approved hash="106,1,45.72,109.22,EN_GATE_OUT,,,,,"/>
-<approved hash="106,1,45.72,106.68,GAIN_OUT,,,,,"/>
-<approved hash="106,1,45.72,111.76,GPIO2,,,,,"/>
-<approved hash="106,1,45.72,96.52,POWER_ENABLE_IN,,,,,"/>
-<approved hash="106,1,45.72,91.44,USART_RX,,,,,"/>
-<approved hash="106,1,45.72,93.98,USART_TX,,,,,"/>
-<approved hash="106,1,45.72,132.08,USB+,,,,,"/>
-<approved hash="106,1,45.72,129.54,USB-,,,,,"/>
-<approved hash="106,1,45.72,127,USB_VBUS,,,,,"/>
-<approved hash="110,1,360.68,101.6,CAN1_VDD,GNDD,,,,"/>
-<approved hash="110,1,360.68,101.6,CAN1_VDD,GNDD,,,,"/>
-<approved hash="110,1,358.14,121.92,N$22,N$23,,,,"/>
-<approved hash="110,1,358.14,121.92,N$22,N$23,,,,"/>
+<approved hash="104,1,119.38,167.64,IC6,AVDD,N$37,,,"/>
+<approved hash="104,1,119.38,165.1,IC6,AGND,GND,,,"/>
+<approved hash="104,1,152.4,165.1,IC6,PVDD1,VBAT,,,"/>
+<approved hash="104,1,152.4,226.06,IC6,PVDD2,VBAT,,,"/>
+<approved hash="104,1,152.4,228.6,IC6,PVDD2,VBAT,,,"/>
+<approved hash="104,1,134.62,160.02,IC6,POWERPAD,GND,,,"/>
+<approved hash="206,1,152.4,220.98,N$4,,,,,"/>
+<approved hash="206,1,152.4,218.44,N$4,,,,,"/>
 <approved hash="113,1,193.571,130.071,FRAME1,,,,,"/>
-<approved hash="113,2,91.971,66.571,FRAME2,,,,,"/>
 </errors>
 </schematic>
 </drawing>

--- a/bloxa.sch
+++ b/bloxa.sch
@@ -67,6 +67,7 @@
 <layer number="57" name="tCAD" color="12" fill="1" visible="no" active="no"/>
 <layer number="58" name="bCAD" color="9" fill="1" visible="no" active="no"/>
 <layer number="59" name="Invisible" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
 <layer number="61" name="stand" color="7" fill="1" visible="no" active="no"/>
 <layer number="88" name="SimResults" color="9" fill="1" visible="yes" active="yes"/>
 <layer number="89" name="SimProbes" color="9" fill="1" visible="yes" active="yes"/>
@@ -114,15 +115,26 @@
 <layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="133" name="bottom_silk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="134" name="silk_top" color="7" fill="1" visible="no" active="yes"/>
+<layer number="135" name="silk_bottom" color="7" fill="1" visible="no" active="yes"/>
+<layer number="136" name="silktop" color="7" fill="1" visible="no" active="yes"/>
+<layer number="137" name="silkbottom" color="7" fill="1" visible="no" active="yes"/>
+<layer number="138" name="EEE" color="7" fill="1" visible="no" active="yes"/>
+<layer number="139" name="_tKeepout" color="7" fill="1" visible="no" active="yes"/>
+<layer number="141" name="ASSEMBLY_TOP" color="7" fill="1" visible="no" active="yes"/>
+<layer number="143" name="PLACE_BOUND_TOP" color="7" fill="1" visible="no" active="yes"/>
 <layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="145" name="DrillLegend_01-16" color="2" fill="9" visible="yes" active="yes"/>
 <layer number="146" name="DrillLegend_01-20" color="3" fill="9" visible="yes" active="yes"/>
+<layer number="147" name="PIN_NUMBER" color="7" fill="1" visible="no" active="yes"/>
 <layer number="150" name="Notes" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="151" name="HeatSink" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="152" name="_bDocu" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="153" name="FabDoc1" color="6" fill="1" visible="no" active="no"/>
 <layer number="154" name="FabDoc2" color="2" fill="1" visible="no" active="no"/>
 <layer number="155" name="FabDoc3" color="7" fill="15" visible="no" active="no"/>
+<layer number="166" name="AntennaArea" color="7" fill="1" visible="no" active="yes"/>
+<layer number="168" name="4mmHeightArea" color="7" fill="1" visible="no" active="yes"/>
 <layer number="199" name="Contour" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="200" name="200bmp" color="1" fill="10" visible="yes" active="yes"/>
 <layer number="201" name="201bmp" color="2" fill="10" visible="yes" active="yes"/>
@@ -2615,76 +2627,11 @@ DIN A3, landscape with location and doc. field</description>
 <rectangle x1="-1.65" y1="-0.25" x2="-0.75" y2="0.25" layer="51"/>
 <circle x="-1" y="1.6" radius="0.111803125" width="0.1" layer="21"/>
 </package>
-<package name="0805_LED" urn="urn:adsk.eagle:footprint:1040134/1" library_version="1">
-<smd name="A" x="-0.9525" y="0" dx="0.9" dy="1.3" layer="1"/>
-<smd name="C" x="1.0475" y="0" dx="0.9" dy="1.3" layer="1"/>
-<wire x1="-0.9525" y1="0.6" x2="1.0475" y2="0.6" width="0.127" layer="51"/>
-<wire x1="1.0475" y1="0.6" x2="1.0475" y2="-0.6" width="0.127" layer="51"/>
-<wire x1="1.0475" y1="-0.6" x2="-0.9525" y2="-0.6" width="0.127" layer="51"/>
-<wire x1="-0.9525" y1="-0.6" x2="-0.9525" y2="0.6" width="0.127" layer="51"/>
-<wire x1="0.62" y1="0.58" x2="0.62" y2="-0.59" width="0.127" layer="51" style="dashdot"/>
-<text x="-0.9525" y="-0.635" size="0.508" layer="21">&gt;NAME</text>
-</package>
-<package name="0603_LED" urn="urn:adsk.eagle:footprint:1040135/1" library_version="1">
-<smd name="C" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
-<smd name="A" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
-<text x="0" y="0.9" size="0.4" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<wire x1="-0.275" y1="0.55" x2="-0.275" y2="-0.55" width="0.1" layer="21"/>
-<wire x1="-0.275" y1="-0.55" x2="-0.175" y2="-0.55" width="0.1" layer="21"/>
-<wire x1="-0.175" y1="-0.55" x2="-0.175" y2="0.55" width="0.1" layer="21"/>
-<wire x1="-0.175" y1="0.55" x2="-0.275" y2="0.55" width="0.1" layer="21"/>
-<wire x1="-1.2" y1="0.6" x2="1.2" y2="0.6" width="0.1" layer="21"/>
-<wire x1="1.2" y1="0.6" x2="1.2" y2="-0.6" width="0.1" layer="21"/>
-<wire x1="1.2" y1="-0.6" x2="-1.2" y2="-0.6" width="0.1" layer="21"/>
-<wire x1="-1.2" y1="-0.6" x2="-1.2" y2="0.6" width="0.1" layer="21"/>
-</package>
-<package name="0402_LED" urn="urn:adsk.eagle:footprint:1040136/1" library_version="1">
-<smd name="C" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<smd name="A" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
-<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<wire x1="-0.95" y1="0.5" x2="0.95" y2="0.5" width="0.15" layer="21"/>
-<wire x1="0.95" y1="0.5" x2="0.95" y2="-0.5" width="0.15" layer="21"/>
-<wire x1="0.95" y1="-0.5" x2="-0.95" y2="-0.5" width="0.15" layer="21"/>
-<wire x1="-0.95" y1="-0.5" x2="-0.95" y2="0.5" width="0.15" layer="21"/>
-<wire x1="-0.4" y1="0.5" x2="-0.4" y2="-0.5" width="0.15" layer="51"/>
-</package>
-<package name="LITE_ON_RGB_LED" urn="urn:adsk.eagle:footprint:1040103/1" library_version="1">
-<smd name="R" x="-0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="G" x="0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="+" x="-0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
-<smd name="B" x="0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
-<text x="0" y="1.75" size="0.6" layer="25" font="vector" ratio="15" rot="R180" align="center">&gt;NAME</text>
-<wire x1="-0.95" y1="1.35" x2="0.95" y2="1.35" width="0.1524" layer="21"/>
-<wire x1="0.95" y1="1.35" x2="0.95" y2="-1.35" width="0.1524" layer="21"/>
-<wire x1="0.95" y1="-1.35" x2="-0.95" y2="-1.35" width="0.1524" layer="21"/>
-<wire x1="-0.95" y1="-1.35" x2="-0.95" y2="1.35" width="0.1524" layer="21"/>
-<circle x="-1.25" y="1.25" radius="0.1" width="0.1524" layer="21"/>
-</package>
 </packages>
 <packages3d>
 <package3d name="SOT26" urn="urn:adsk.eagle:package:1040217/3" type="model" library_version="19">
 <packageinstances>
 <packageinstance name="SOT26"/>
-</packageinstances>
-</package3d>
-<package3d name="0805_LED" urn="urn:adsk.eagle:package:1040214/1" type="box" library_version="15" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="0805_LED"/>
-</packageinstances>
-</package3d>
-<package3d name="0603_LED" urn="urn:adsk.eagle:package:1040215/1" type="box" library_version="15" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="0603_LED"/>
-</packageinstances>
-</package3d>
-<package3d name="0402_LED" urn="urn:adsk.eagle:package:1040216/2" type="model" library_version="15" library_locally_modified="yes">
-<packageinstances>
-<packageinstance name="0402_LED"/>
-</packageinstances>
-</package3d>
-<package3d name="LITE_ON_RGB_LED" urn="urn:adsk.eagle:package:1040199/2" type="model" library_version="18">
-<packageinstances>
-<packageinstance name="LITE_ON_RGB_LED"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -2702,64 +2649,6 @@ DIN A3, landscape with location and doc. field</description>
 <wire x1="12.7" y1="15.24" x2="0" y2="15.24" width="0.254" layer="94"/>
 <text x="6.35" y="16.51" size="2.54" layer="97" font="vector" ratio="15" align="center">&gt;NAME</text>
 <text x="6.35" y="-1.27" size="1.778" layer="97" font="vector" ratio="15" align="center">TPD3S014</text>
-</symbol>
-<symbol name="LED" urn="urn:adsk.eagle:symbol:1040133/1" library_version="1">
-<wire x1="0" y1="1.27" x2="0" y2="-1.27" width="0.254" layer="94"/>
-<wire x1="0" y1="-1.27" x2="2.54" y2="0" width="0.254" layer="94"/>
-<wire x1="2.54" y1="0" x2="0" y2="1.27" width="0.254" layer="94"/>
-<wire x1="2.54" y1="1.27" x2="2.54" y2="0" width="0.254" layer="94"/>
-<wire x1="2.54" y1="0" x2="2.54" y2="-1.27" width="0.254" layer="94"/>
-<wire x1="2.54" y1="2.54" x2="5.08" y2="5.08" width="0.254" layer="94"/>
-<wire x1="5.08" y1="5.08" x2="3.81" y2="5.08" width="0.254" layer="94"/>
-<wire x1="5.08" y1="3.81" x2="5.08" y2="5.08" width="0.254" layer="94"/>
-<pin name="A" x="-2.54" y="0" visible="off" length="short"/>
-<pin name="C" x="5.08" y="0" visible="off" length="short" rot="R180"/>
-<text x="-2.54" y="1.778" size="1.27" layer="95">&gt;NAME</text>
-</symbol>
-<symbol name="RGB_LED" urn="urn:adsk.eagle:symbol:1040102/1" library_version="1">
-<wire x1="5.08" y1="8.89" x2="5.08" y2="7.62" width="0.254" layer="94"/>
-<wire x1="5.08" y1="7.62" x2="5.08" y2="6.35" width="0.254" layer="94"/>
-<wire x1="5.08" y1="6.35" x2="7.62" y2="7.62" width="0.254" layer="94"/>
-<wire x1="7.62" y1="7.62" x2="5.08" y2="8.89" width="0.254" layer="94"/>
-<wire x1="7.62" y1="8.89" x2="7.62" y2="7.62" width="0.254" layer="94"/>
-<wire x1="7.62" y1="7.62" x2="7.62" y2="6.35" width="0.254" layer="94"/>
-<wire x1="5.08" y1="13.97" x2="5.08" y2="12.7" width="0.254" layer="94"/>
-<wire x1="5.08" y1="12.7" x2="5.08" y2="11.43" width="0.254" layer="94"/>
-<wire x1="5.08" y1="11.43" x2="7.62" y2="12.7" width="0.254" layer="94"/>
-<wire x1="7.62" y1="12.7" x2="5.08" y2="13.97" width="0.254" layer="94"/>
-<wire x1="7.62" y1="13.97" x2="7.62" y2="12.7" width="0.254" layer="94"/>
-<wire x1="7.62" y1="12.7" x2="7.62" y2="11.43" width="0.254" layer="94"/>
-<wire x1="7.62" y1="17.78" x2="10.16" y2="20.32" width="0.254" layer="94"/>
-<wire x1="10.16" y1="20.32" x2="8.89" y2="20.32" width="0.254" layer="94"/>
-<wire x1="10.16" y1="19.05" x2="10.16" y2="20.32" width="0.254" layer="94"/>
-<wire x1="5.08" y1="3.81" x2="5.08" y2="2.54" width="0.254" layer="94"/>
-<wire x1="5.08" y1="2.54" x2="5.08" y2="1.27" width="0.254" layer="94"/>
-<wire x1="5.08" y1="1.27" x2="7.62" y2="2.54" width="0.254" layer="94"/>
-<wire x1="7.62" y1="2.54" x2="5.08" y2="3.81" width="0.254" layer="94"/>
-<wire x1="7.62" y1="3.81" x2="7.62" y2="2.54" width="0.254" layer="94"/>
-<wire x1="7.62" y1="2.54" x2="7.62" y2="1.27" width="0.254" layer="94"/>
-<wire x1="0" y1="15.24" x2="0" y2="7.62" width="0.254" layer="94"/>
-<wire x1="0" y1="7.62" x2="0" y2="0" width="0.254" layer="94"/>
-<wire x1="0" y1="0" x2="10.16" y2="0" width="0.254" layer="94"/>
-<wire x1="5.08" y1="17.78" x2="7.62" y2="20.32" width="0.254" layer="94"/>
-<wire x1="7.62" y1="20.32" x2="6.35" y2="20.32" width="0.254" layer="94"/>
-<wire x1="7.62" y1="19.05" x2="7.62" y2="20.32" width="0.254" layer="94"/>
-<wire x1="10.16" y1="15.24" x2="10.16" y2="0" width="0.254" layer="94"/>
-<wire x1="10.16" y1="15.24" x2="0" y2="15.24" width="0.254" layer="94"/>
-<wire x1="5.08" y1="2.54" x2="2.54" y2="2.54" width="0.254" layer="94"/>
-<wire x1="2.54" y1="2.54" x2="2.54" y2="7.62" width="0.254" layer="94"/>
-<wire x1="2.54" y1="7.62" x2="2.54" y2="12.7" width="0.254" layer="94"/>
-<wire x1="2.54" y1="12.7" x2="5.08" y2="12.7" width="0.254" layer="94"/>
-<wire x1="5.08" y1="7.62" x2="2.54" y2="7.62" width="0.254" layer="94"/>
-<wire x1="2.54" y1="7.62" x2="0" y2="7.62" width="0.254" layer="94"/>
-<pin name="G" x="12.7" y="7.62" visible="off" length="middle" rot="R180"/>
-<pin name="R" x="12.7" y="12.7" visible="off" length="middle" rot="R180"/>
-<pin name="B" x="12.7" y="2.54" visible="off" length="middle" rot="R180"/>
-<pin name="A" x="-2.54" y="7.62" visible="off" length="short"/>
-<text x="5.08" y="16.256" size="1.27" layer="95" font="vector" ratio="15" align="center">&gt;NAME</text>
-<text x="10.922" y="12.954" size="1.27" layer="97">R</text>
-<text x="10.922" y="7.874" size="1.27" layer="97">G</text>
-<text x="10.922" y="2.794" size="1.27" layer="97">B</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -2785,97 +2674,6 @@ DIN A3, landscape with location and doc. field</description>
 <attribute name="DIGIKEY#" value="296-38835-1-ND" constant="no"/>
 <attribute name="MANF" value="Texas Instruments" constant="no"/>
 <attribute name="MANF#" value="TPD3S014DBVR" constant="no"/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="LED" urn="urn:adsk.eagle:component:1040261/6" prefix="LED" uservalue="yes" library_version="15" library_locally_modified="yes">
-<gates>
-<gate name="G$1" symbol="LED" x="-2.54" y="0"/>
-</gates>
-<devices>
-<device name="-0805" package="0805_LED">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:1040214/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-0603" package="0603_LED">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:1040215/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-0402" package="0402_LED">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:1040216/2"/>
-</package3dinstances>
-<technologies>
-<technology name="-BLUE">
-<attribute name="COLOR" value="BLUE" constant="no"/>
-<attribute name="DIGIKEY#" value="511-1615-1-ND" constant="no"/>
-<attribute name="MANF" value="Rohm Semiconductor" constant="no"/>
-<attribute name="MANF#" value="SMLP12BC7TT86" constant="no"/>
-</technology>
-<technology name="-GREEN">
-<attribute name="COLOR" value="GREEN" constant="no"/>
-<attribute name="DIGIKEY#" value="511-1652-1-ND" constant="no"/>
-<attribute name="MANF" value="Rohm Semiconductor" constant="no"/>
-<attribute name="MANF#" value="SML-P11MTT86" constant="no"/>
-</technology>
-<technology name="-ORANGE">
-<attribute name="COLOR" value="ORANGE" constant="no"/>
-<attribute name="DIGIKEY#" value="511-1651-1-ND" constant="no"/>
-<attribute name="MANF" value="Rohm Semiconductor" constant="no"/>
-<attribute name="MANF#" value="SML-P11DTT86" constant="no"/>
-</technology>
-<technology name="-RED">
-<attribute name="COLOR" value="RED" constant="no"/>
-<attribute name="DIGIKEY#" value="511-1653-1-ND" constant="no"/>
-<attribute name="MANF" value="Rohm Semiconductor" constant="no"/>
-<attribute name="MANF#" value="SML-P11UTT86" constant="no"/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="LTST-C19HE1WT" urn="urn:adsk.eagle:component:1040242/6" prefix="LED" library_version="18">
-<gates>
-<gate name="G$1" symbol="RGB_LED" x="-2.54" y="-7.62"/>
-</gates>
-<devices>
-<device name="" package="LITE_ON_RGB_LED">
-<connects>
-<connect gate="G$1" pin="A" pad="+"/>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="G" pad="G"/>
-<connect gate="G$1" pin="R" pad="R"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:1040199/2"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="DIGIKEY#" value="160-2162-1-ND" constant="no"/>
-<attribute name="MANF" value="Lite-On Inc" constant="no"/>
-<attribute name="MANF#" value="LTST-C19HE1WT" constant="no"/>
 </technology>
 </technologies>
 </device>
@@ -3168,6 +2966,18 @@ DIN A3, landscape with location and doc. field</description>
 <circle x="0" y="0" radius="1.5" width="0.127" layer="41"/>
 <smd name="P$1" x="0" y="0" dx="1.016" dy="1.016" layer="1" roundness="100" cream="no"/>
 </package>
+<package name="0606" urn="urn:adsk.eagle:footprint:20072924/1" library_version="83" library_locally_modified="yes">
+<circle x="-1.25" y="1.25" radius="0.1" width="0.1524" layer="21"/>
+<wire x1="-0.95" y1="1.35" x2="0.95" y2="1.35" width="0.1524" layer="21"/>
+<wire x1="0.95" y1="1.35" x2="0.95" y2="-1.35" width="0.1524" layer="21"/>
+<wire x1="0.95" y1="-1.35" x2="-0.95" y2="-1.35" width="0.1524" layer="21"/>
+<wire x1="-0.95" y1="-1.35" x2="-0.95" y2="1.35" width="0.1524" layer="21"/>
+<smd name="+" x="-0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="B" x="0.425" y="-0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="G" x="0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
+<smd name="R" x="-0.425" y="0.725" dx="0.65" dy="0.85" layer="1"/>
+<text x="0" y="1.75" size="0.6" layer="25" font="vector" ratio="15" rot="R180" align="center">&gt;NAME</text>
+</package>
 </packages>
 <packages3d>
 <package3d name="SENSE-0.6" urn="urn:adsk.eagle:package:7365871/1" type="box" library_version="8">
@@ -3189,6 +2999,11 @@ DIN A3, landscape with location and doc. field</description>
 <package3d name="CONNECTION" urn="urn:adsk.eagle:package:7439847/1" type="box" library_version="9">
 <packageinstances>
 <packageinstance name="CONNECTION"/>
+</packageinstances>
+</package3d>
+<package3d name="0606" urn="urn:adsk.eagle:package:20072926/2" type="model" library_version="83" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="0606"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -3218,6 +3033,52 @@ DIN A3, landscape with location and doc. field</description>
 </symbol>
 <symbol name="FIDUCIAL" library_version="9" library_locally_modified="yes">
 <circle x="0" y="0" radius="2.54" width="0.254" layer="94"/>
+</symbol>
+<symbol name="RGB_LED" urn="urn:adsk.eagle:symbol:20072922/2" library_version="83" library_locally_modified="yes">
+<wire x1="5.08" y1="8.89" x2="5.08" y2="7.62" width="0.254" layer="94"/>
+<wire x1="5.08" y1="7.62" x2="5.08" y2="6.35" width="0.254" layer="94"/>
+<wire x1="5.08" y1="6.35" x2="7.62" y2="7.62" width="0.254" layer="94"/>
+<wire x1="7.62" y1="7.62" x2="5.08" y2="8.89" width="0.254" layer="94"/>
+<wire x1="7.62" y1="8.89" x2="7.62" y2="7.62" width="0.254" layer="94"/>
+<wire x1="7.62" y1="7.62" x2="7.62" y2="6.35" width="0.254" layer="94"/>
+<wire x1="5.08" y1="13.97" x2="5.08" y2="12.7" width="0.254" layer="94"/>
+<wire x1="5.08" y1="12.7" x2="5.08" y2="11.43" width="0.254" layer="94"/>
+<wire x1="5.08" y1="11.43" x2="7.62" y2="12.7" width="0.254" layer="94"/>
+<wire x1="7.62" y1="12.7" x2="5.08" y2="13.97" width="0.254" layer="94"/>
+<wire x1="7.62" y1="13.97" x2="7.62" y2="12.7" width="0.254" layer="94"/>
+<wire x1="7.62" y1="12.7" x2="7.62" y2="11.43" width="0.254" layer="94"/>
+<wire x1="5.08" y1="3.81" x2="5.08" y2="2.54" width="0.254" layer="94"/>
+<wire x1="5.08" y1="2.54" x2="5.08" y2="1.27" width="0.254" layer="94"/>
+<wire x1="5.08" y1="1.27" x2="7.62" y2="2.54" width="0.254" layer="94"/>
+<wire x1="7.62" y1="2.54" x2="5.08" y2="3.81" width="0.254" layer="94"/>
+<wire x1="7.62" y1="3.81" x2="7.62" y2="2.54" width="0.254" layer="94"/>
+<wire x1="7.62" y1="2.54" x2="7.62" y2="1.27" width="0.254" layer="94"/>
+<wire x1="0" y1="15.24" x2="0" y2="7.62" width="0.254" layer="94"/>
+<wire x1="0" y1="7.62" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="10.16" y2="0" width="0.254" layer="94"/>
+<wire x1="10.16" y1="15.24" x2="10.16" y2="0" width="0.254" layer="94"/>
+<wire x1="10.16" y1="15.24" x2="0" y2="15.24" width="0.254" layer="94"/>
+<wire x1="5.08" y1="2.54" x2="2.54" y2="2.54" width="0.254" layer="94"/>
+<wire x1="2.54" y1="2.54" x2="2.54" y2="7.62" width="0.254" layer="94"/>
+<wire x1="2.54" y1="7.62" x2="2.54" y2="12.7" width="0.254" layer="94"/>
+<wire x1="2.54" y1="12.7" x2="5.08" y2="12.7" width="0.254" layer="94"/>
+<wire x1="5.08" y1="7.62" x2="2.54" y2="7.62" width="0.254" layer="94"/>
+<wire x1="2.54" y1="7.62" x2="0" y2="7.62" width="0.254" layer="94"/>
+<wire x1="7.62" y1="17.78" x2="9.144" y2="19.304" width="0.254" layer="94"/>
+<wire x1="9.144" y1="19.304" x2="8.128" y2="18.796" width="0.254" layer="94"/>
+<wire x1="8.636" y1="18.288" x2="9.144" y2="19.304" width="0.254" layer="94"/>
+<wire x1="6.096" y1="17.78" x2="7.62" y2="19.304" width="0.254" layer="94"/>
+<wire x1="7.62" y1="19.304" x2="6.604" y2="18.796" width="0.254" layer="94"/>
+<wire x1="7.112" y1="18.288" x2="7.62" y2="19.304" width="0.254" layer="94"/>
+<pin name="A" x="-2.54" y="7.62" visible="off" length="short"/>
+<pin name="B" x="12.7" y="2.54" visible="off" length="middle" rot="R180"/>
+<pin name="G" x="12.7" y="7.62" visible="off" length="middle" rot="R180"/>
+<pin name="R" x="12.7" y="12.7" visible="off" length="middle" rot="R180"/>
+<text x="5.08" y="16.51" size="1.27" layer="95" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="10.922" y="12.954" size="1.27" layer="97">R</text>
+<text x="10.922" y="7.874" size="1.27" layer="97">G</text>
+<text x="10.922" y="2.794" size="1.27" layer="97">B</text>
+<text x="5.08" y="-1.27" size="0.889" layer="97" font="vector" ratio="15" align="center">&gt;MANF#</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -3319,6 +3180,32 @@ DIN A3, landscape with location and doc. field</description>
 </device>
 </devices>
 </deviceset>
+<deviceset name="LTST-C19HE1WT" urn="urn:adsk.eagle:component:20072928/3" prefix="LED" library_version="83" library_locally_modified="yes">
+<description>LED RGB DIFFUSED CHIP SMD</description>
+<gates>
+<gate name="G$1" symbol="RGB_LED" x="-2.54" y="-7.62"/>
+</gates>
+<devices>
+<device name="" package="0606">
+<connects>
+<connect gate="G$1" pin="A" pad="+"/>
+<connect gate="G$1" pin="B" pad="B"/>
+<connect gate="G$1" pin="G" pad="G"/>
+<connect gate="G$1" pin="R" pad="R"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:20072926/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="DIGIKEY#" value="160-2162-1-ND" constant="no"/>
+<attribute name="MANF" value="Lite-On Inc" constant="no"/>
+<attribute name="MANF#" value="LTST-C19HE1WT" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
 </devicesets>
 </library>
 <library name="TVS_diodes" urn="urn:adsk.eagle:library:3333632">
@@ -3368,8 +3255,8 @@ DIN A3, landscape with location and doc. field</description>
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="PTVS36VP1UP,115" urn="urn:adsk.eagle:component:6533207/2" prefix="D" library_version="7">
-<description>TVS DIODE CFP5</description>
+<deviceset name="PTVS33VP1UTP,115" urn="urn:adsk.eagle:component:11612760/1" prefix="D" library_version="22">
+<description>53.3V Clamp 11.3A Ipp Tvs Diode Surface Mount CFP5</description>
 <gates>
 <gate name="G$1" symbol="TVS" x="0" y="0"/>
 </gates>
@@ -3384,9 +3271,9 @@ DIN A3, landscape with location and doc. field</description>
 </package3dinstances>
 <technologies>
 <technology name="-36V">
-<attribute name="DIGIKEY#" value="1727-4439-2-ND" constant="no"/>
+<attribute name="DIGIKEY#" value="1727-1411-1-ND" constant="no"/>
 <attribute name="MANF" value="Nexperia USA Inc" constant="no"/>
-<attribute name="MANF#" value="PTVS36VP1UP,115" constant="no"/>
+<attribute name="MANF#" value="PTVS33VP1UTP,115" constant="no"/>
 </technology>
 </technologies>
 </device>
@@ -3611,6 +3498,59 @@ http://www.bccomponents.com/</description>
 <wire x1="-4.05" y1="-1.75" x2="-4.05" y2="1.75" width="0.1" layer="21"/>
 <text x="0" y="0" size="1.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
+<package name="LED0402" urn="urn:adsk.eagle:footprint:2539447/1" library_version="54">
+<smd name="A" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="C" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.4064" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="0.45" x2="0.1" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.1" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="-0.45" x2="0.1" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.1" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.1" y1="0.45" x2="0.1" y2="-0.45" width="0.1" layer="21"/>
+</package>
+<package name="LED0603" urn="urn:adsk.eagle:footprint:2539448/1" library_version="54">
+<smd name="A" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<smd name="C" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<wire x1="-1.125" y1="0.55" x2="0.25" y2="0.55" width="0.1" layer="21"/>
+<wire x1="0.25" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="-0.55" x2="0.25" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="0.25" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="0.25" y1="0.55" x2="0.25" y2="-0.55" width="0.1" layer="21"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
+</package>
+<package name="LED0805" urn="urn:adsk.eagle:footprint:2539449/1" library_version="54">
+<smd name="A" x="-1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<smd name="C" x="1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<wire x1="-1.65" y1="0.85" x2="0.4" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.4" y1="0.85" x2="1.65" y2="0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="0.85" x2="1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="-0.85" x2="0.4" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="0.4" y1="-0.85" x2="-1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="-1.65" y1="-0.85" x2="-1.65" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.4" y1="0.85" x2="0.4" y2="-0.85" width="0.1" layer="21"/>
+<text x="0" y="0" size="0.635" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="LED1206" urn="urn:adsk.eagle:footprint:2539450/1" library_version="54">
+<smd name="A" x="-1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
+<smd name="C" x="1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
+<text x="0" y="0" size="0.762" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-2.2" y1="1" x2="0.9" y2="1" width="0.15" layer="21"/>
+<wire x1="0.9" y1="1" x2="2.2" y2="1" width="0.15" layer="21"/>
+<wire x1="2.2" y1="1" x2="2.2" y2="-1" width="0.15" layer="21"/>
+<wire x1="2.2" y1="-1" x2="0.9" y2="-1" width="0.15" layer="21"/>
+<wire x1="0.9" y1="-1" x2="-2.2" y2="-1" width="0.15" layer="21"/>
+<wire x1="-2.2" y1="-1" x2="-2.2" y2="1" width="0.15" layer="21"/>
+<wire x1="0.9" y1="1" x2="0.9" y2="-1" width="0.15" layer="21"/>
+</package>
 </packages>
 <packages3d>
 <package3d name="153CLV-0810" urn="urn:adsk.eagle:package:4491937/3" type="model" library_version="25" library_locally_modified="yes">
@@ -3710,6 +3650,26 @@ http://www.bccomponents.com/</description>
 <packageinstance name="R2512"/>
 </packageinstances>
 </package3d>
+<package3d name="LED0402" urn="urn:adsk.eagle:package:2539470/2" type="model" library_version="54">
+<packageinstances>
+<packageinstance name="LED0402"/>
+</packageinstances>
+</package3d>
+<package3d name="LED0603" urn="urn:adsk.eagle:package:2539471/2" type="model" library_version="54">
+<packageinstances>
+<packageinstance name="LED0603"/>
+</packageinstances>
+</package3d>
+<package3d name="LED0805" urn="urn:adsk.eagle:package:2539472/2" type="model" library_version="54">
+<packageinstances>
+<packageinstance name="LED0805"/>
+</packageinstances>
+</package3d>
+<package3d name="LED1206" urn="urn:adsk.eagle:package:2539473/2" type="model" library_version="54">
+<packageinstances>
+<packageinstance name="LED1206"/>
+</packageinstances>
+</package3d>
 </packages3d>
 <symbols>
 <symbol name="CPOL-1" urn="urn:adsk.eagle:symbol:4855519/1" library_version="25" library_locally_modified="yes">
@@ -3739,6 +3699,23 @@ http://www.bccomponents.com/</description>
 <text x="0.254" y="-2.032" size="0.762" layer="96">&gt;TOLERANCE</text>
 <pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
 <pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
+</symbol>
+<symbol name="LED" urn="urn:adsk.eagle:symbol:2539429/1" library_version="54">
+<wire x1="-2.54" y1="1.27" x2="-2.54" y2="-1.27" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="-1.27" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="-2.54" y2="1.27" width="0.254" layer="94"/>
+<wire x1="0" y1="1.27" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="0" y2="-1.27" width="0.254" layer="94"/>
+<wire x1="0" y1="2.54" x2="1.524" y2="4.064" width="0.254" layer="94"/>
+<wire x1="1.524" y1="4.064" x2="0.508" y2="3.556" width="0.254" layer="94"/>
+<wire x1="1.016" y1="3.048" x2="1.524" y2="4.064" width="0.254" layer="94"/>
+<wire x1="-1.524" y1="2.54" x2="0" y2="4.064" width="0.254" layer="94"/>
+<wire x1="0" y1="4.064" x2="-1.016" y2="3.556" width="0.254" layer="94"/>
+<wire x1="-0.508" y1="3.048" x2="0" y2="4.064" width="0.254" layer="94"/>
+<pin name="A" x="-5.08" y="0" visible="off" length="short"/>
+<pin name="C" x="2.54" y="0" visible="off" length="short" rot="R180"/>
+<text x="-2.54" y="-2.54" size="1.27" layer="95" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="-4.318" y="0.508" size="0.635" layer="96" font="vector" align="center">&gt;COLOR</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -4099,6 +4076,82 @@ http://www.bccomponents.com/</description>
 </device>
 </devices>
 </deviceset>
+<deviceset name="LED" urn="urn:adsk.eagle:component:2539475/3" prefix="LED" library_version="54">
+<description>SMD LED</description>
+<gates>
+<gate name="G$1" symbol="LED" x="2.54" y="0"/>
+</gates>
+<devices>
+<device name="-0402" package="LED0402">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539470/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-0603" package="LED0603">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539471/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-0805" package="LED0805">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539472/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-1206" package="LED1206">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539473/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
 </devicesets>
 </library>
 <library name="serial_interfaces" urn="urn:adsk.eagle:library:4770999">
@@ -4248,7 +4301,7 @@ http://www.bccomponents.com/</description>
 <attributes>
 </attributes>
 <variantdefs>
-<variantdef name="Basic" current="yes"/>
+<variantdef name="Basic"/>
 <variantdef name="nocaps"/>
 </variantdefs>
 <classes>
@@ -4401,8 +4454,13 @@ http://www.bccomponents.com/</description>
 <part name="GND17" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GNDD" device="" value="GNDD"/>
 <part name="C14" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" deviceset="4.7µF" device="-0603" package3d_urn="urn:adsk.eagle:package:2539381/2" technology="-25V_10%_X6S" value="4.7µF"/>
 <part name="GND19" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GNDD" device="" value="GNDD"/>
-<part name="LED4" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" deviceset="LTST-C19HE1WT" device="" package3d_urn="urn:adsk.eagle:package:1040199/2"/>
-<part name="LED2" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" deviceset="LED" device="-0402" package3d_urn="urn:adsk.eagle:package:1040216/2" technology="-GREEN" value="GREEN"/>
+<part name="LED4" library="misc" library_urn="urn:adsk.eagle:library:5347860" deviceset="LTST-C19HE1WT" device="" package3d_urn="urn:adsk.eagle:package:20072926/2"/>
+<part name="LED2" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="LED" device="-0402" package3d_urn="urn:adsk.eagle:package:2539470/2" value="GREEN">
+<attribute name="COLOR" value="GREEN"/>
+<attribute name="DIGIKEY#" value="1830-IN-S42BT5GCT-ND"/>
+<attribute name="MANF" value="Inolux"/>
+<attribute name="MANF#" value="IN-S42BT5G"/>
+</part>
 <part name="+P9" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="5V" device=""/>
 <part name="R5" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="1K" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-1%" value="1K"/>
 <part name="R6" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="1K" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-1%" value="1K"/>
@@ -4461,7 +4519,7 @@ http://www.bccomponents.com/</description>
 <variant name="Basic" populate="no"/>
 </part>
 <part name="GND2" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="PGND" device="" value="PGND"/>
-<part name="D1" library="TVS_diodes" library_urn="urn:adsk.eagle:library:3333632" deviceset="PTVS36VP1UP,115" device="-SOD128" package3d_urn="urn:adsk.eagle:package:6533206/2" technology="-36V"/>
+<part name="D1" library="TVS_diodes" library_urn="urn:adsk.eagle:library:3333632" deviceset="PTVS33VP1UTP,115" device="-SOD128" package3d_urn="urn:adsk.eagle:package:6533206/2" technology="-36V"/>
 <part name="C1" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="CPOL" device="-RADIAL_SIDE-8X21.5" package3d_urn="urn:adsk.eagle:package:7189333/3" value="180µF">
 <variant name="nocaps" populate="no"/>
 </part>
@@ -4499,10 +4557,10 @@ http://www.bccomponents.com/</description>
 <part name="GND11" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 <part name="GND21" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 <part name="GND6" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
-<part name="LED1" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" deviceset="LED" device="-0402" package3d_urn="urn:adsk.eagle:package:1040216/2" technology="-GREEN" value="GREEN">
-<variant name="Basic" populate="no"/>
+<part name="LED1" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="LED" device="-0402" package3d_urn="urn:adsk.eagle:package:2539470/2" value="GREEN">
+<variant name="Basic" populate="no" value="LED-0402"/>
 </part>
-<part name="LED3" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" deviceset="LTST-C19HE1WT" device="" package3d_urn="urn:adsk.eagle:package:1040199/2">
+<part name="LED3" library="misc" library_urn="urn:adsk.eagle:library:5347860" deviceset="LTST-C19HE1WT" device="" package3d_urn="urn:adsk.eagle:package:20072926/2">
 <variant name="Basic" populate="no"/>
 </part>
 <part name="R14" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="R" device="-0402" package3d_urn="urn:adsk.eagle:package:2539456/2" technology="-1%" value="680R">
@@ -4529,16 +4587,16 @@ http://www.bccomponents.com/</description>
 <wire x1="60.96" y1="167.64" x2="60.96" y2="83.82" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="10.16" y1="167.64" x2="60.96" y2="167.64" width="0.1524" layer="97" style="shortdash"/>
 <text x="43.18" y="165.1" size="1.778" layer="97" font="vector" align="center">High side interface</text>
-<wire x1="285.75" y1="69.85" x2="285.75" y2="142.24" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="220.98" y1="69.85" x2="285.75" y2="69.85" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="285.75" y1="142.24" x2="220.98" y2="142.24" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="220.98" y1="142.24" x2="220.98" y2="69.85" width="0.1524" layer="97" style="shortdash"/>
-<text x="241.3" y="137.16" size="2.54" layer="97" font="vector" align="center-left">INDICATION</text>
-<text x="132.08" y="248.92" size="1.27" layer="97">The minimum specific bulk capacitance is 20 μF/A 
+<wire x1="288.29" y1="63.5" x2="288.29" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
+<wire x1="223.52" y1="63.5" x2="288.29" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
+<wire x1="288.29" y1="134.62" x2="223.52" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
+<wire x1="223.52" y1="134.62" x2="223.52" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
+<text x="243.84" y="132.08" size="2.54" layer="97" font="vector" align="center-left">INDICATION</text>
+<text x="132.08" y="248.92" size="1.27" layer="97" font="vector">The minimum specific bulk capacitance is 20 μF/A 
 (e.g. an ESC rated for 20 A DC requires at least 400 μF).</text>
-<text x="193.04" y="236.22" size="2.54" layer="97">PHASE_A</text>
-<text x="256.54" y="236.22" size="2.54" layer="97">PHASE_B</text>
-<text x="317.5" y="236.22" size="2.54" layer="97">PHASE_C</text>
+<text x="193.04" y="241.3" size="2.54" layer="97" font="vector">PHASE_A</text>
+<text x="256.54" y="241.3" size="2.54" layer="97" font="vector">PHASE_B</text>
+<text x="317.5" y="241.3" size="2.54" layer="97" font="vector">PHASE_C</text>
 <wire x1="190.5" y1="246.38" x2="254" y2="246.38" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="254" y1="246.38" x2="314.96" y2="246.38" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="314.96" y1="246.38" x2="375.92" y2="246.38" width="0.1524" layer="97" style="shortdash"/>
@@ -4555,61 +4613,62 @@ http://www.bccomponents.com/</description>
 <wire x1="132.08" y1="205.74" x2="190.5" y2="205.74" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="190.246" y1="164.084" x2="131.826" y2="164.084" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="131.826" y1="164.084" x2="132.08" y2="205.74" width="0.1524" layer="97" style="shortdash"/>
-<text x="134.62" y="213.36" size="2.54" layer="97">Capacitor battery</text>
-<text x="134.62" y="208.28" size="1.27" layer="97">These capacitors should be placed 
+<text x="134.62" y="213.36" size="2.54" layer="97" font="vector">Capacitor battery</text>
+<text x="134.62" y="208.28" size="1.27" layer="97" font="vector">These capacitors should be placed 
 as close as possible to the power transistors.</text>
-<text x="134.62" y="200.66" size="3.81" layer="97">Temperature sensor</text>
-<text x="134.62" y="165.1" size="2.54" layer="97">Place close to power mosfets</text>
+<text x="134.62" y="200.66" size="3.048" layer="97" font="vector">Temperature sensor</text>
+<text x="134.62" y="165.1" size="2.54" layer="97" font="vector">Place close to power mosfets</text>
 <wire x1="289.56" y1="134.62" x2="289.56" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="289.56" y1="63.5" x2="375.92" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="375.92" y1="63.5" x2="375.92" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="375.92" y1="134.62" x2="289.56" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
-<text x="25.4" y="48.26" size="1.27" layer="97" font="vector" ratio="15" align="center">DC power, W</text>
-<text x="43.18" y="48.26" size="1.27" layer="97" font="vector" ratio="15" align="center">Phase current, I</text>
-<text x="63.5" y="48.26" size="1.27" layer="97" font="vector" ratio="15" align="center">Total losses, W</text>
-<text x="86.36" y="48.26" size="1.27" layer="97" font="vector" ratio="15" align="center">Efficiency, %</text>
-<text x="25.4" y="43.18" size="1.27" layer="97" font="vector" ratio="15" align="center">100</text>
-<text x="25.4" y="40.64" size="1.27" layer="97" font="vector" ratio="15" align="center">150</text>
-<text x="25.4" y="38.1" size="1.27" layer="97" font="vector" ratio="15" align="center">200</text>
-<text x="25.4" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">250</text>
-<text x="25.4" y="33.02" size="1.27" layer="97" font="vector" ratio="15" align="center">300</text>
-<text x="55.88" y="27.94" size="1.27" layer="97" font="vector" ratio="15" align="center">The table is valid for 26.4 V supply voltage which is discharched 8S battery</text>
-<text x="43.18" y="43.18" size="1.27" layer="97" font="vector" ratio="15" align="center">4.8</text>
-<text x="63.5" y="43.18" size="1.27" layer="97" font="vector" ratio="15" align="center">1.7</text>
-<text x="86.36" y="43.18" size="1.27" layer="97" font="vector" ratio="15" align="center">98.3</text>
-<text x="43.18" y="40.64" size="1.27" layer="97" font="vector" ratio="15" align="center">7.2</text>
-<text x="63.5" y="40.64" size="1.27" layer="97" font="vector" ratio="15" align="center">3</text>
-<text x="86.36" y="40.64" size="1.27" layer="97" font="vector" ratio="15" align="center">98</text>
-<text x="43.18" y="38.1" size="1.27" layer="97" font="vector" ratio="15" align="center">9.6</text>
-<text x="63.5" y="38.1" size="1.27" layer="97" font="vector" ratio="15" align="center">4.5</text>
-<text x="86.36" y="38.1" size="1.27" layer="97" font="vector" ratio="15" align="center">97.7</text>
-<text x="43.18" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">12</text>
-<text x="63.5" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">6.3</text>
-<text x="86.36" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">97.5</text>
-<text x="43.18" y="33.02" size="1.27" layer="97" font="vector" ratio="15" align="center">14.4</text>
-<text x="63.5" y="33.02" size="1.27" layer="97" font="vector" ratio="15" align="center">8.4</text>
-<text x="86.36" y="33.02" size="1.27" layer="97" font="vector" ratio="15" align="center">97.2</text>
-<text x="58.42" y="53.34" size="1.27" layer="97" font="vector" ratio="15" align="center">Power losses for different power levels</text>
+<text x="17.78" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">DC power, W</text>
+<text x="35.56" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">Phase current, I</text>
+<text x="55.88" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">Total losses, W</text>
+<text x="78.74" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">Efficiency, %</text>
+<text x="17.78" y="30.48" size="1.27" layer="97" font="vector" ratio="15" align="center">100</text>
+<text x="17.78" y="27.94" size="1.27" layer="97" font="vector" ratio="15" align="center">150</text>
+<text x="17.78" y="25.4" size="1.27" layer="97" font="vector" ratio="15" align="center">200</text>
+<text x="17.78" y="22.86" size="1.27" layer="97" font="vector" ratio="15" align="center">250</text>
+<text x="17.78" y="20.32" size="1.27" layer="97" font="vector" ratio="15" align="center">300</text>
+<text x="48.26" y="15.24" size="1.27" layer="97" font="vector" ratio="15" align="center">The table is valid for 26.4 V supply voltage
+which is the same as a discharched 8S Li-ion battery</text>
+<text x="35.56" y="30.48" size="1.27" layer="97" font="vector" ratio="15" align="center">4.8</text>
+<text x="55.88" y="30.48" size="1.27" layer="97" font="vector" ratio="15" align="center">1.7</text>
+<text x="78.74" y="30.48" size="1.27" layer="97" font="vector" ratio="15" align="center">98.3</text>
+<text x="35.56" y="27.94" size="1.27" layer="97" font="vector" ratio="15" align="center">7.2</text>
+<text x="55.88" y="27.94" size="1.27" layer="97" font="vector" ratio="15" align="center">3</text>
+<text x="78.74" y="27.94" size="1.27" layer="97" font="vector" ratio="15" align="center">98</text>
+<text x="35.56" y="25.4" size="1.27" layer="97" font="vector" ratio="15" align="center">9.6</text>
+<text x="55.88" y="25.4" size="1.27" layer="97" font="vector" ratio="15" align="center">4.5</text>
+<text x="78.74" y="25.4" size="1.27" layer="97" font="vector" ratio="15" align="center">97.7</text>
+<text x="35.56" y="22.86" size="1.27" layer="97" font="vector" ratio="15" align="center">12</text>
+<text x="55.88" y="22.86" size="1.27" layer="97" font="vector" ratio="15" align="center">6.3</text>
+<text x="78.74" y="22.86" size="1.27" layer="97" font="vector" ratio="15" align="center">97.5</text>
+<text x="35.56" y="20.32" size="1.27" layer="97" font="vector" ratio="15" align="center">14.4</text>
+<text x="55.88" y="20.32" size="1.27" layer="97" font="vector" ratio="15" align="center">8.4</text>
+<text x="78.74" y="20.32" size="1.27" layer="97" font="vector" ratio="15" align="center">97.2</text>
+<text x="50.8" y="40.64" size="1.27" layer="97" font="vector" ratio="15" align="center">Power losses for different power levels</text>
 <text x="63.5" y="111.76" size="1.778" layer="97" font="vector" ratio="15" align="center-left">R14 sets overcurrent protection trip level. 
 680R sets ir arount 35A, which is 2.5 times 
 higher than maximum phase current for 300W DC power 
 when running on discharged 8S battery</text>
-<wire x1="17.78" y1="50.8" x2="33.02" y2="50.8" width="0.1524" layer="97"/>
-<wire x1="33.02" y1="50.8" x2="53.34" y2="50.8" width="0.1524" layer="97"/>
-<wire x1="53.34" y1="50.8" x2="76.2" y2="50.8" width="0.1524" layer="97"/>
-<wire x1="76.2" y1="50.8" x2="96.52" y2="50.8" width="0.1524" layer="97"/>
-<wire x1="96.52" y1="50.8" x2="96.52" y2="45.72" width="0.1524" layer="97"/>
-<wire x1="96.52" y1="45.72" x2="96.52" y2="30.48" width="0.1524" layer="97"/>
-<wire x1="96.52" y1="30.48" x2="76.2" y2="30.48" width="0.1524" layer="97"/>
-<wire x1="76.2" y1="30.48" x2="53.34" y2="30.48" width="0.1524" layer="97"/>
-<wire x1="53.34" y1="30.48" x2="33.02" y2="30.48" width="0.1524" layer="97"/>
-<wire x1="33.02" y1="30.48" x2="17.78" y2="30.48" width="0.1524" layer="97"/>
-<wire x1="17.78" y1="30.48" x2="17.78" y2="45.72" width="0.1524" layer="97"/>
-<wire x1="17.78" y1="45.72" x2="17.78" y2="50.8" width="0.1524" layer="97"/>
-<wire x1="17.78" y1="45.72" x2="96.52" y2="45.72" width="0.1524" layer="97"/>
-<wire x1="76.2" y1="50.8" x2="76.2" y2="30.48" width="0.1524" layer="97"/>
-<wire x1="53.34" y1="50.8" x2="53.34" y2="30.48" width="0.1524" layer="97"/>
-<wire x1="33.02" y1="50.8" x2="33.02" y2="30.48" width="0.1524" layer="97"/>
+<wire x1="10.16" y1="38.1" x2="25.4" y2="38.1" width="0.1524" layer="97"/>
+<wire x1="25.4" y1="38.1" x2="45.72" y2="38.1" width="0.1524" layer="97"/>
+<wire x1="45.72" y1="38.1" x2="68.58" y2="38.1" width="0.1524" layer="97"/>
+<wire x1="68.58" y1="38.1" x2="88.9" y2="38.1" width="0.1524" layer="97"/>
+<wire x1="88.9" y1="38.1" x2="88.9" y2="33.02" width="0.1524" layer="97"/>
+<wire x1="88.9" y1="33.02" x2="88.9" y2="17.78" width="0.1524" layer="97"/>
+<wire x1="88.9" y1="17.78" x2="68.58" y2="17.78" width="0.1524" layer="97"/>
+<wire x1="68.58" y1="17.78" x2="45.72" y2="17.78" width="0.1524" layer="97"/>
+<wire x1="45.72" y1="17.78" x2="25.4" y2="17.78" width="0.1524" layer="97"/>
+<wire x1="25.4" y1="17.78" x2="10.16" y2="17.78" width="0.1524" layer="97"/>
+<wire x1="10.16" y1="17.78" x2="10.16" y2="33.02" width="0.1524" layer="97"/>
+<wire x1="10.16" y1="33.02" x2="10.16" y2="38.1" width="0.1524" layer="97"/>
+<wire x1="10.16" y1="33.02" x2="88.9" y2="33.02" width="0.1524" layer="97"/>
+<wire x1="68.58" y1="38.1" x2="68.58" y2="17.78" width="0.1524" layer="97"/>
+<wire x1="45.72" y1="38.1" x2="45.72" y2="17.78" width="0.1524" layer="97"/>
+<wire x1="25.4" y1="38.1" x2="25.4" y2="17.78" width="0.1524" layer="97"/>
 </plain>
 <instances>
 <instance part="+P2" gate="G$1" x="45.72" y="238.76" smashed="yes">
@@ -4738,11 +4797,11 @@ when running on discharged 8S battery</text>
 <instance part="PAD1" gate="G$1" x="48.26" y="160.02" smashed="yes" rot="MR0">
 <attribute name="NAME" x="48.26" y="161.29" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
-<instance part="C10" gate="G$1" x="299.72" y="116.84" smashed="yes" rot="R270">
-<attribute name="NAME" x="298.831" y="115.57" size="1.27" layer="95" rot="R270" align="center-left"/>
-<attribute name="VALUE" x="299.974" y="118.11" size="0.762" layer="96" rot="R270" align="bottom-right"/>
-<attribute name="PACKAGE" x="299.212" y="118.872" size="0.508" layer="97" rot="R90" align="center"/>
-<attribute name="VOLTAGE" x="299.974" y="114.554" size="0.762" layer="96" rot="R270" align="bottom-center"/>
+<instance part="C10" gate="G$1" x="299.72" y="114.3" smashed="yes" rot="R270">
+<attribute name="NAME" x="298.831" y="113.03" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="299.974" y="115.57" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="299.212" y="116.332" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="299.974" y="112.014" size="0.762" layer="96" font="vector" rot="R270" align="bottom-center"/>
 </instance>
 <instance part="CON1" gate="G$1" x="365.76" y="129.54" smashed="yes" rot="R270">
 <attribute name="NAME" x="372.11" y="123.19" size="1.778" layer="95" font="vector" ratio="15" rot="R90" align="center"/>
@@ -4772,22 +4831,22 @@ when running on discharged 8S battery</text>
 <attribute name="VALUE" x="302.26" y="87.376" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
 <instance part="C11" gate="G$1" x="302.26" y="76.2" smashed="yes" rot="R270">
-<attribute name="NAME" x="301.371" y="74.93" size="1.27" layer="95" rot="R270" align="center-left"/>
-<attribute name="VALUE" x="302.514" y="77.47" size="0.762" layer="96" rot="R270" align="bottom-right"/>
-<attribute name="PACKAGE" x="301.752" y="78.232" size="0.508" layer="97" rot="R90" align="center"/>
-<attribute name="VOLTAGE" x="302.514" y="73.914" size="0.762" layer="96" rot="R270" align="bottom-center"/>
+<attribute name="NAME" x="301.371" y="74.93" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="302.514" y="77.47" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="301.752" y="78.232" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="302.514" y="73.914" size="0.762" layer="96" font="vector" rot="R270" align="bottom-center"/>
 </instance>
 <instance part="C13" gate="G$1" x="340.36" y="76.2" smashed="yes" rot="R90">
-<attribute name="NAME" x="341.249" y="77.47" size="1.27" layer="95" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="340.106" y="74.93" size="0.762" layer="96" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="340.868" y="74.168" size="0.508" layer="97" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="340.106" y="78.486" size="0.762" layer="96" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="341.249" y="77.47" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="340.106" y="74.93" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="340.868" y="74.168" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="340.106" y="78.486" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="C12" gate="G$1" x="335.28" y="76.2" smashed="yes" rot="R90">
-<attribute name="NAME" x="336.169" y="77.47" size="1.27" layer="95" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="335.026" y="74.93" size="0.762" layer="96" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="335.788" y="74.168" size="0.508" layer="97" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="335.026" y="78.486" size="0.762" layer="96" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="336.169" y="77.47" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="335.026" y="74.93" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="335.788" y="74.168" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="335.026" y="78.486" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="GND16" gate="G$1" x="335.28" y="68.58" smashed="yes">
 <attribute name="VALUE" x="335.28" y="66.548" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
@@ -4796,55 +4855,56 @@ when running on discharged 8S battery</text>
 <attribute name="VALUE" x="340.36" y="66.548" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
 <instance part="C14" gate="G$1" x="345.44" y="76.2" smashed="yes" rot="R90">
-<attribute name="NAME" x="346.329" y="77.47" size="1.27" layer="95" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="345.186" y="74.93" size="0.762" layer="96" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="345.948" y="74.168" size="0.508" layer="97" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="345.186" y="78.486" size="0.762" layer="96" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="346.329" y="77.47" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="345.186" y="74.93" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="345.948" y="74.168" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="345.186" y="78.486" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="GND19" gate="G$1" x="345.44" y="68.58" smashed="yes">
 <attribute name="VALUE" x="345.44" y="66.548" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="LED4" gate="G$1" x="264.16" y="121.92" smashed="yes" rot="R270">
-<attribute name="NAME" x="280.416" y="116.84" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
+<instance part="LED4" gate="G$1" x="266.7" y="116.84" smashed="yes" rot="R270">
+<attribute name="NAME" x="283.21" y="111.76" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
+<attribute name="MANF#" x="265.43" y="111.76" size="0.889" layer="97" font="vector" ratio="15" rot="R270" align="center"/>
 </instance>
-<instance part="LED2" gate="G$1" x="231.14" y="121.92" smashed="yes" rot="R270">
-<attribute name="COLOR" x="231.14" y="121.92" size="1.27" layer="96" font="vector" rot="R270" align="center-left" display="off"/>
-<attribute name="NAME" x="232.918" y="124.46" size="1.27" layer="95" rot="R270"/>
+<instance part="LED2" gate="G$1" x="233.68" y="114.3" smashed="yes" rot="R270">
+<attribute name="NAME" x="231.14" y="116.84" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
+<attribute name="COLOR" x="234.188" y="118.618" size="0.635" layer="96" font="vector" rot="R270" align="center"/>
 </instance>
-<instance part="+P9" gate="G$1" x="231.14" y="132.08" smashed="yes">
-<attribute name="VALUE" x="231.14" y="135.636" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="+P9" gate="G$1" x="233.68" y="127" smashed="yes">
+<attribute name="VALUE" x="233.68" y="130.556" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="R5" gate="G$1" x="266.7" y="93.98" smashed="yes" rot="MR270">
-<attribute name="NAME" x="266.7" y="93.98" size="1.27" layer="95" rot="MR270" align="center"/>
-<attribute name="VALUE" x="268.732" y="94.234" size="0.762" layer="96" rot="MR270" align="bottom-right"/>
-<attribute name="PACKAGE" x="266.192" y="97.79" size="0.508" layer="95" rot="MR270" align="center"/>
-<attribute name="TOLERANCE" x="268.732" y="93.726" size="0.762" layer="96" rot="MR270"/>
+<instance part="R5" gate="G$1" x="269.24" y="88.9" smashed="yes" rot="MR270">
+<attribute name="NAME" x="269.24" y="88.9" size="1.27" layer="95" font="vector" rot="MR270" align="center"/>
+<attribute name="VALUE" x="271.272" y="89.154" size="0.762" layer="96" font="vector" rot="MR270" align="bottom-right"/>
+<attribute name="PACKAGE" x="268.732" y="92.71" size="0.508" layer="95" font="vector" rot="MR270" align="center"/>
+<attribute name="TOLERANCE" x="271.272" y="88.646" size="0.762" layer="96" font="vector" rot="MR270"/>
 </instance>
-<instance part="R6" gate="G$1" x="271.78" y="93.98" smashed="yes" rot="MR270">
-<attribute name="NAME" x="271.78" y="93.98" size="1.27" layer="95" rot="MR270" align="center"/>
-<attribute name="VALUE" x="273.812" y="94.234" size="0.762" layer="96" rot="MR270" align="bottom-right"/>
-<attribute name="PACKAGE" x="271.272" y="97.79" size="0.508" layer="95" rot="MR270" align="center"/>
-<attribute name="TOLERANCE" x="273.812" y="93.726" size="0.762" layer="96" rot="MR270"/>
+<instance part="R6" gate="G$1" x="274.32" y="88.9" smashed="yes" rot="MR270">
+<attribute name="NAME" x="274.32" y="88.9" size="1.27" layer="95" font="vector" rot="MR270" align="center"/>
+<attribute name="VALUE" x="276.352" y="89.154" size="0.762" layer="96" font="vector" rot="MR270" align="bottom-right"/>
+<attribute name="PACKAGE" x="273.812" y="92.71" size="0.508" layer="95" font="vector" rot="MR270" align="center"/>
+<attribute name="TOLERANCE" x="276.352" y="88.646" size="0.762" layer="96" font="vector" rot="MR270"/>
 </instance>
-<instance part="R7" gate="G$1" x="276.86" y="93.98" smashed="yes" rot="MR270">
-<attribute name="NAME" x="276.86" y="93.98" size="1.27" layer="95" rot="MR270" align="center"/>
-<attribute name="VALUE" x="278.892" y="94.234" size="0.762" layer="96" rot="MR270" align="bottom-right"/>
-<attribute name="PACKAGE" x="276.352" y="97.79" size="0.508" layer="95" rot="MR270" align="center"/>
-<attribute name="TOLERANCE" x="278.892" y="93.726" size="0.762" layer="96" rot="MR270"/>
+<instance part="R7" gate="G$1" x="279.4" y="88.9" smashed="yes" rot="MR270">
+<attribute name="NAME" x="279.4" y="88.9" size="1.27" layer="95" font="vector" rot="MR270" align="center"/>
+<attribute name="VALUE" x="281.432" y="89.154" size="0.762" layer="96" font="vector" rot="MR270" align="bottom-right"/>
+<attribute name="PACKAGE" x="278.892" y="92.71" size="0.508" layer="95" font="vector" rot="MR270" align="center"/>
+<attribute name="TOLERANCE" x="281.432" y="88.646" size="0.762" layer="96" font="vector" rot="MR270"/>
 </instance>
-<instance part="+P11" gate="G$1" x="271.78" y="132.08" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="271.78" y="135.636" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
+<instance part="+P11" gate="G$1" x="274.32" y="127" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="274.32" y="130.556" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
-<instance part="R3" gate="G$1" x="231.14" y="106.68" smashed="yes" rot="R90">
-<attribute name="NAME" x="231.14" y="106.68" size="1.27" layer="95" rot="R90" align="center"/>
-<attribute name="VALUE" x="233.172" y="106.426" size="0.762" layer="96" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="230.632" y="102.87" size="0.508" layer="95" rot="R90" align="center"/>
-<attribute name="TOLERANCE" x="233.172" y="106.934" size="0.762" layer="96" rot="R90"/>
+<instance part="R3" gate="G$1" x="233.68" y="101.6" smashed="yes" rot="R90">
+<attribute name="NAME" x="233.68" y="101.6" size="1.27" layer="95" font="vector" rot="R90" align="center"/>
+<attribute name="VALUE" x="235.712" y="101.346" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="233.172" y="97.79" size="0.508" layer="95" font="vector" rot="R90" align="center"/>
+<attribute name="TOLERANCE" x="235.712" y="101.854" size="0.762" layer="96" font="vector" rot="R90"/>
 </instance>
 <instance part="FRAME1" gate="G$1" x="0" y="0" smashed="yes">
-<attribute name="DRAWING_NAME" x="344.17" y="15.24" size="2.54" layer="94"/>
-<attribute name="LAST_DATE_TIME" x="344.17" y="10.16" size="2.286" layer="94"/>
-<attribute name="SHEET" x="357.505" y="5.08" size="2.54" layer="94"/>
+<attribute name="DRAWING_NAME" x="344.17" y="15.24" size="2.54" layer="94" font="vector"/>
+<attribute name="LAST_DATE_TIME" x="344.17" y="10.16" size="2.286" layer="94" font="vector"/>
+<attribute name="SHEET" x="357.505" y="5.08" size="2.54" layer="94" font="vector"/>
 </instance>
 <instance part="GND3" gate="G$1" x="142.24" y="220.98" smashed="yes">
 <attribute name="VALUE" x="142.24" y="219.71" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
@@ -4870,22 +4930,22 @@ when running on discharged 8S battery</text>
 <attribute name="MANF#" x="181.61" y="182.626" size="0.762" layer="95" font="vector" ratio="15" rot="R180" align="bottom-center"/>
 </instance>
 <instance part="C5" gate="G$1" x="167.64" y="182.88" smashed="yes" rot="R270">
-<attribute name="NAME" x="166.751" y="181.61" size="1.27" layer="95" rot="R270" align="center-left"/>
-<attribute name="VALUE" x="167.894" y="184.15" size="0.762" layer="96" rot="R270" align="bottom-right"/>
-<attribute name="PACKAGE" x="167.132" y="184.912" size="0.508" layer="97" rot="R90" align="center"/>
-<attribute name="VOLTAGE" x="167.894" y="180.594" size="0.762" layer="96" rot="R270" align="bottom-center"/>
+<attribute name="NAME" x="166.751" y="181.61" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="167.894" y="184.15" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="167.132" y="184.912" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="167.894" y="180.594" size="0.762" layer="96" font="vector" rot="R270" align="bottom-center"/>
 </instance>
 <instance part="R1" gate="G$1" x="220.98" y="228.6" smashed="yes">
-<attribute name="NAME" x="220.98" y="228.6" size="1.27" layer="95" align="center"/>
-<attribute name="VALUE" x="220.726" y="226.568" size="0.762" layer="96" align="bottom-right"/>
-<attribute name="PACKAGE" x="217.17" y="229.108" size="0.508" layer="95" align="center"/>
-<attribute name="TOLERANCE" x="221.234" y="226.568" size="0.762" layer="96"/>
+<attribute name="NAME" x="220.98" y="228.6" size="1.27" layer="95" font="vector" align="center"/>
+<attribute name="VALUE" x="220.726" y="226.568" size="0.762" layer="96" font="vector" align="bottom-right"/>
+<attribute name="PACKAGE" x="217.17" y="229.108" size="0.508" layer="95" font="vector" align="center"/>
+<attribute name="TOLERANCE" x="221.234" y="226.568" size="0.762" layer="96" font="vector"/>
 </instance>
 <instance part="R2" gate="G$1" x="220.98" y="213.36" smashed="yes">
-<attribute name="NAME" x="220.98" y="213.36" size="1.27" layer="95" align="center"/>
-<attribute name="VALUE" x="220.726" y="211.328" size="0.762" layer="96" align="bottom-right"/>
-<attribute name="PACKAGE" x="217.17" y="213.868" size="0.508" layer="95" align="center"/>
-<attribute name="TOLERANCE" x="221.234" y="211.328" size="0.762" layer="96"/>
+<attribute name="NAME" x="220.98" y="213.36" size="1.27" layer="95" font="vector" align="center"/>
+<attribute name="VALUE" x="220.726" y="211.328" size="0.762" layer="96" font="vector" align="bottom-right"/>
+<attribute name="PACKAGE" x="217.17" y="213.868" size="0.508" layer="95" font="vector" align="center"/>
+<attribute name="TOLERANCE" x="221.234" y="211.328" size="0.762" layer="96" font="vector"/>
 </instance>
 <instance part="PAD45" gate="G$1" x="307.34" y="218.44" smashed="yes" rot="MR0">
 <attribute name="NAME" x="307.34" y="219.71" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
@@ -4895,56 +4955,56 @@ when running on discharged 8S battery</text>
 <attribute name="VALUE" x="299.72" y="182.88" size="1.016" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
 </instance>
 <instance part="R8" gate="G$1" x="287.02" y="226.06" smashed="yes">
-<attribute name="NAME" x="287.02" y="226.06" size="1.27" layer="95" align="center"/>
-<attribute name="VALUE" x="286.766" y="224.028" size="0.762" layer="96" align="bottom-right"/>
-<attribute name="PACKAGE" x="283.21" y="226.568" size="0.508" layer="95" align="center"/>
-<attribute name="TOLERANCE" x="287.274" y="224.028" size="0.762" layer="96"/>
+<attribute name="NAME" x="287.02" y="226.06" size="1.27" layer="95" font="vector" align="center"/>
+<attribute name="VALUE" x="286.766" y="224.028" size="0.762" layer="96" font="vector" align="bottom-right"/>
+<attribute name="PACKAGE" x="283.21" y="226.568" size="0.508" layer="95" font="vector" align="center"/>
+<attribute name="TOLERANCE" x="287.274" y="224.028" size="0.762" layer="96" font="vector"/>
 </instance>
 <instance part="R9" gate="G$1" x="287.02" y="210.82" smashed="yes">
-<attribute name="NAME" x="287.02" y="210.82" size="1.27" layer="95" align="center"/>
-<attribute name="VALUE" x="286.766" y="208.788" size="0.762" layer="96" align="bottom-right"/>
-<attribute name="PACKAGE" x="283.21" y="211.328" size="0.508" layer="95" align="center"/>
-<attribute name="TOLERANCE" x="287.274" y="208.788" size="0.762" layer="96"/>
+<attribute name="NAME" x="287.02" y="210.82" size="1.27" layer="95" font="vector" align="center"/>
+<attribute name="VALUE" x="286.766" y="208.788" size="0.762" layer="96" font="vector" align="bottom-right"/>
+<attribute name="PACKAGE" x="283.21" y="211.328" size="0.508" layer="95" font="vector" align="center"/>
+<attribute name="TOLERANCE" x="287.274" y="208.788" size="0.762" layer="96" font="vector"/>
 </instance>
 <instance part="PAD46" gate="G$1" x="368.3" y="218.44" smashed="yes" rot="MR0">
 <attribute name="NAME" x="368.3" y="219.71" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
 <instance part="R11" gate="G$1" x="347.98" y="226.06" smashed="yes">
-<attribute name="NAME" x="347.98" y="226.06" size="1.27" layer="95" align="center"/>
-<attribute name="VALUE" x="347.726" y="224.028" size="0.762" layer="96" align="bottom-right"/>
-<attribute name="PACKAGE" x="344.17" y="226.568" size="0.508" layer="95" align="center"/>
-<attribute name="TOLERANCE" x="348.234" y="224.028" size="0.762" layer="96"/>
+<attribute name="NAME" x="347.98" y="226.06" size="1.27" layer="95" font="vector" align="center"/>
+<attribute name="VALUE" x="347.726" y="224.028" size="0.762" layer="96" font="vector" align="bottom-right"/>
+<attribute name="PACKAGE" x="344.17" y="226.568" size="0.508" layer="95" font="vector" align="center"/>
+<attribute name="TOLERANCE" x="348.234" y="224.028" size="0.762" layer="96" font="vector"/>
 </instance>
 <instance part="R12" gate="G$1" x="347.98" y="210.82" smashed="yes">
-<attribute name="NAME" x="347.98" y="210.82" size="1.27" layer="95" align="center"/>
-<attribute name="VALUE" x="347.726" y="208.788" size="0.762" layer="96" align="bottom-right"/>
-<attribute name="PACKAGE" x="344.17" y="211.328" size="0.508" layer="95" align="center"/>
-<attribute name="TOLERANCE" x="348.234" y="208.788" size="0.762" layer="96"/>
+<attribute name="NAME" x="347.98" y="210.82" size="1.27" layer="95" font="vector" align="center"/>
+<attribute name="VALUE" x="347.726" y="208.788" size="0.762" layer="96" font="vector" align="bottom-right"/>
+<attribute name="PACKAGE" x="344.17" y="211.328" size="0.508" layer="95" font="vector" align="center"/>
+<attribute name="TOLERANCE" x="348.234" y="208.788" size="0.762" layer="96" font="vector"/>
 </instance>
 <instance part="S1" gate="G$1" x="355.6" y="190.5" smashed="yes" rot="R180"/>
 <instance part="C7" gate="G$1" x="175.26" y="231.14" smashed="yes" rot="R90">
-<attribute name="NAME" x="176.149" y="232.41" size="1.27" layer="95" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="175.006" y="229.87" size="0.762" layer="96" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="175.768" y="229.108" size="0.508" layer="97" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="175.006" y="233.426" size="0.762" layer="96" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="176.149" y="232.41" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="175.006" y="229.87" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="175.768" y="229.108" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="175.006" y="233.426" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="C8" gate="G$1" x="180.34" y="231.14" smashed="yes" rot="R90">
-<attribute name="NAME" x="181.229" y="232.41" size="1.27" layer="95" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="180.086" y="229.87" size="0.762" layer="96" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="180.848" y="229.108" size="0.508" layer="97" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="180.086" y="233.426" size="0.762" layer="96" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="181.229" y="232.41" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="180.086" y="229.87" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="180.848" y="229.108" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="180.086" y="233.426" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="C9" gate="G$1" x="185.42" y="231.14" smashed="yes" rot="R90">
-<attribute name="NAME" x="186.309" y="232.41" size="1.27" layer="95" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="185.166" y="229.87" size="0.762" layer="96" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="185.928" y="229.108" size="0.508" layer="97" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="185.166" y="233.426" size="0.762" layer="96" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="186.309" y="232.41" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="185.166" y="229.87" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="185.928" y="229.108" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="185.166" y="233.426" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="C6" gate="G$1" x="170.18" y="231.14" smashed="yes" rot="R90">
-<attribute name="NAME" x="171.069" y="232.41" size="1.27" layer="95" rot="R90" align="center-left"/>
-<attribute name="VALUE" x="169.926" y="229.87" size="0.762" layer="96" rot="R90" align="bottom-right"/>
-<attribute name="PACKAGE" x="170.688" y="229.108" size="0.508" layer="97" rot="R270" align="center"/>
-<attribute name="VOLTAGE" x="169.926" y="233.426" size="0.762" layer="96" rot="R90" align="bottom-center"/>
+<attribute name="NAME" x="171.069" y="232.41" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
+<attribute name="VALUE" x="169.926" y="229.87" size="0.762" layer="96" font="vector" rot="R90" align="bottom-right"/>
+<attribute name="PACKAGE" x="170.688" y="229.108" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
+<attribute name="VOLTAGE" x="169.926" y="233.426" size="0.762" layer="96" font="vector" rot="R90" align="bottom-center"/>
 </instance>
 <instance part="GND8" gate="G$1" x="177.8" y="220.98" smashed="yes">
 <attribute name="VALUE" x="177.8" y="219.71" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
@@ -5000,18 +5060,18 @@ when running on discharged 8S battery</text>
 <instance part="GND7" gate="G$1" x="167.64" y="172.72" smashed="yes">
 <attribute name="VALUE" x="167.64" y="171.45" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="PAD43" gate="G$1" x="114.3" y="223.52" smashed="yes">
-<attribute name="NAME" x="114.3" y="224.79" size="1.27" layer="95" font="vector" ratio="15" align="center"/>
+<instance part="PAD43" gate="G$1" x="88.9" y="231.14" smashed="yes">
+<attribute name="NAME" x="88.9" y="232.41" size="1.27" layer="95" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="PAD42" gate="G$1" x="114.3" y="233.68" smashed="yes">
-<attribute name="NAME" x="114.3" y="234.95" size="1.27" layer="95" font="vector" ratio="15" align="center"/>
+<instance part="PAD42" gate="G$1" x="88.9" y="241.3" smashed="yes">
+<attribute name="NAME" x="88.9" y="242.57" size="1.27" layer="95" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="GND2" gate="G$1" x="119.38" y="218.44" smashed="yes">
-<attribute name="VALUE" x="119.38" y="217.17" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
+<instance part="GND2" gate="G$1" x="93.98" y="226.06" smashed="yes">
+<attribute name="VALUE" x="93.98" y="224.79" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="D1" gate="G$1" x="119.38" y="228.6" smashed="yes" rot="R90">
-<attribute name="NAME" x="116.84" y="228.6" size="1.27" layer="95" font="vector" ratio="15" rot="R90" align="center"/>
-<attribute name="MANF#" x="121.92" y="228.6" size="1.016" layer="95" font="vector" ratio="15" rot="R90" align="center"/>
+<instance part="D1" gate="G$1" x="93.98" y="236.22" smashed="yes" rot="R90">
+<attribute name="NAME" x="91.44" y="236.22" size="1.27" layer="95" font="vector" ratio="15" rot="R90" align="center"/>
+<attribute name="MANF#" x="96.52" y="236.22" size="1.016" layer="95" font="vector" ratio="15" rot="R90" align="center"/>
 </instance>
 <instance part="C1" gate="G$1" x="142.24" y="231.14" smashed="yes" rot="R90">
 <attribute name="NAME" x="143.2814" y="232.791" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
@@ -5034,8 +5094,8 @@ when running on discharged 8S battery</text>
 <attribute name="VALUE" x="150.8506" y="229.489" size="1.27" layer="96" font="vector" rot="R270" align="center-left"/>
 <attribute name="PACKAGE" x="149.098" y="229.616" size="0.762" layer="97" font="vector" rot="R90" align="center-right"/>
 </instance>
-<instance part="+P3" gate="G$1" x="119.38" y="236.22" smashed="yes">
-<attribute name="VALUE" x="119.38" y="239.776" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="+P3" gate="G$1" x="93.98" y="243.84" smashed="yes">
+<attribute name="VALUE" x="93.98" y="247.396" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
 <instance part="+P1" gate="G$1" x="40.64" y="238.76" smashed="yes">
 <attribute name="VALUE" x="40.64" y="242.316" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
@@ -5048,10 +5108,10 @@ when running on discharged 8S battery</text>
 <attribute name="VALUE" x="38.1" y="227.33" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
 <instance part="C4" gate="G$1" x="162.56" y="182.88" smashed="yes" rot="R270">
-<attribute name="NAME" x="161.671" y="181.61" size="1.27" layer="95" rot="R270" align="center-left"/>
-<attribute name="VALUE" x="162.814" y="184.15" size="0.762" layer="96" rot="R270" align="bottom-right"/>
-<attribute name="PACKAGE" x="162.052" y="184.912" size="0.508" layer="97" rot="R90" align="center"/>
-<attribute name="VOLTAGE" x="162.814" y="180.594" size="0.762" layer="96" rot="R270" align="bottom-center"/>
+<attribute name="NAME" x="161.671" y="181.61" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="162.814" y="184.15" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="162.052" y="184.912" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="162.814" y="180.594" size="0.762" layer="96" font="vector" rot="R270" align="bottom-center"/>
 </instance>
 <instance part="J2" gate="G$1" x="335.28" y="144.78" smashed="yes"/>
 <instance part="GND18" gate="G$1" x="340.36" y="139.7" smashed="yes">
@@ -5078,18 +5138,19 @@ when running on discharged 8S battery</text>
 <instance part="GND6" gate="1" x="162.56" y="172.72" smashed="yes">
 <attribute name="VALUE" x="162.56" y="171.45" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="LED1" gate="G$1" x="223.52" y="121.92" smashed="yes" rot="R270">
-<attribute name="COLOR" x="223.52" y="121.92" size="1.27" layer="96" font="vector" rot="R270" align="center-left" display="off"/>
-<attribute name="NAME" x="225.298" y="124.46" size="1.27" layer="95" rot="R270"/>
+<instance part="LED1" gate="G$1" x="226.06" y="114.3" smashed="yes" rot="R270">
+<attribute name="NAME" x="223.52" y="116.84" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
+<attribute name="COLOR" x="226.568" y="118.618" size="0.635" layer="96" font="vector" rot="R270" align="center"/>
 </instance>
-<instance part="LED3" gate="G$1" x="241.3" y="121.92" smashed="yes" rot="R270">
-<attribute name="NAME" x="257.556" y="116.84" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
+<instance part="LED3" gate="G$1" x="243.84" y="116.84" smashed="yes" rot="R270">
+<attribute name="NAME" x="260.35" y="111.76" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
+<attribute name="MANF#" x="242.57" y="111.76" size="0.889" layer="97" font="vector" ratio="15" rot="R270" align="center"/>
 </instance>
 <instance part="R14" gate="G$1" x="25.4" y="116.84" smashed="yes" rot="MR180">
-<attribute name="NAME" x="25.4" y="116.84" size="1.27" layer="95" rot="MR180" align="center"/>
-<attribute name="VALUE" x="25.146" y="118.872" size="0.762" layer="96" rot="MR180" align="bottom-right"/>
-<attribute name="PACKAGE" x="21.59" y="116.332" size="0.508" layer="95" rot="MR180" align="center"/>
-<attribute name="TOLERANCE" x="25.654" y="118.872" size="0.762" layer="96" rot="MR180"/>
+<attribute name="NAME" x="25.4" y="116.84" size="1.27" layer="95" font="vector" rot="MR180" align="center"/>
+<attribute name="VALUE" x="25.146" y="118.872" size="0.762" layer="96" font="vector" rot="MR180" align="bottom-right"/>
+<attribute name="PACKAGE" x="21.59" y="116.332" size="0.508" layer="95" font="vector" rot="MR180" align="center"/>
+<attribute name="TOLERANCE" x="25.654" y="118.872" size="0.762" layer="96" font="vector" rot="MR180"/>
 </instance>
 <instance part="GND25" gate="1" x="17.78" y="111.76" smashed="yes">
 <attribute name="VALUE" x="17.78" y="110.49" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
@@ -5107,70 +5168,70 @@ when running on discharged 8S battery</text>
 <net name="CAN2_TX" class="0">
 <segment>
 <wire x1="45.72" y1="154.94" x2="40.64" y2="154.94" width="0.1524" layer="91"/>
-<label x="40.64" y="154.94" size="1.27" layer="95" rot="MR0" xref="yes"/>
+<label x="40.64" y="154.94" size="1.27" layer="95" font="vector" rot="MR0" xref="yes"/>
 <pinref part="PAD3" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="CAN2_RX" class="0">
 <segment>
 <wire x1="45.72" y1="152.4" x2="40.64" y2="152.4" width="0.1524" layer="91"/>
-<label x="40.64" y="152.4" size="1.27" layer="95" rot="MR0" xref="yes"/>
+<label x="40.64" y="152.4" size="1.27" layer="95" font="vector" rot="MR0" xref="yes"/>
 <pinref part="PAD4" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="CAN1_TX" class="0">
 <segment>
 <wire x1="45.72" y1="160.02" x2="40.64" y2="160.02" width="0.1524" layer="91"/>
-<label x="40.64" y="160.02" size="1.27" layer="95" rot="MR0" xref="yes"/>
+<label x="40.64" y="160.02" size="1.27" layer="95" font="vector" rot="MR0" xref="yes"/>
 <pinref part="PAD1" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <wire x1="320.04" y1="127" x2="317.5" y2="127" width="0.1524" layer="91"/>
 <wire x1="317.5" y1="127" x2="312.42" y2="127" width="0.1524" layer="91"/>
-<label x="312.42" y="127" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="312.42" y="127" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="IC3" gate="G$1" pin="TXD"/>
 </segment>
 </net>
 <net name="RGB_LED_R" class="0">
 <segment>
 <wire x1="45.72" y1="119.38" x2="43.18" y2="119.38" width="0.1524" layer="91"/>
-<label x="43.18" y="119.38" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="119.38" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD12" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R7" gate="G$1" pin="2"/>
-<wire x1="276.86" y1="83.82" x2="276.86" y2="88.9" width="0.1524" layer="91"/>
-<label x="276.86" y="83.82" size="1.27" layer="95" rot="R270" xref="yes"/>
+<wire x1="279.4" y1="78.74" x2="279.4" y2="83.82" width="0.1524" layer="91"/>
+<label x="279.4" y="78.74" size="1.27" layer="95" font="vector" rot="R270" xref="yes"/>
 </segment>
 </net>
 <net name="RGB_LED_G" class="0">
 <segment>
 <wire x1="45.72" y1="121.92" x2="43.18" y2="121.92" width="0.1524" layer="91"/>
-<label x="43.18" y="121.92" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="121.92" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD11" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R6" gate="G$1" pin="2"/>
-<wire x1="271.78" y1="88.9" x2="271.78" y2="83.82" width="0.1524" layer="91"/>
-<label x="271.78" y="83.82" size="1.27" layer="95" rot="R270" xref="yes"/>
+<wire x1="274.32" y1="83.82" x2="274.32" y2="78.74" width="0.1524" layer="91"/>
+<label x="274.32" y="78.74" size="1.27" layer="95" font="vector" rot="R270" xref="yes"/>
 </segment>
 </net>
 <net name="RGB_LED_B" class="0">
 <segment>
 <wire x1="45.72" y1="124.46" x2="43.18" y2="124.46" width="0.1524" layer="91"/>
-<label x="43.18" y="124.46" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="124.46" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD10" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R5" gate="G$1" pin="2"/>
-<wire x1="266.7" y1="88.9" x2="266.7" y2="83.82" width="0.1524" layer="91"/>
-<label x="266.7" y="83.82" size="1.27" layer="95" rot="R270" xref="yes"/>
+<wire x1="269.24" y1="83.82" x2="269.24" y2="78.74" width="0.1524" layer="91"/>
+<label x="269.24" y="78.74" size="1.27" layer="95" font="vector" rot="R270" xref="yes"/>
 </segment>
 </net>
 <net name="GPIO1" class="0">
 <segment>
 <wire x1="45.72" y1="114.3" x2="43.18" y2="114.3" width="0.1524" layer="91"/>
-<label x="43.18" y="114.3" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="114.3" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD14" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
@@ -5181,7 +5242,7 @@ when running on discharged 8S battery</text>
 </net>
 <net name="PHASE_A_GND" class="0">
 <segment>
-<label x="45.72" y="213.36" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="213.36" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="48.26" y1="213.36" x2="45.72" y2="213.36" width="0.1524" layer="91"/>
 <pinref part="PAD28" gate="G$1" pin="P$1"/>
 </segment>
@@ -5192,12 +5253,12 @@ when running on discharged 8S battery</text>
 <junction x="236.22" y="198.12"/>
 <pinref part="R4" gate="G$1" pin="1"/>
 <pinref part="Q1" gate="T2" pin="S"/>
-<label x="218.44" y="198.12" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="218.44" y="198.12" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B" class="1">
 <segment>
-<label x="45.72" y="208.28" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="208.28" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="208.28" x2="48.26" y2="208.28" width="0.1524" layer="91"/>
 <pinref part="PAD30" gate="G$1" pin="P$1"/>
 </segment>
@@ -5210,12 +5271,12 @@ when running on discharged 8S battery</text>
 <junction x="302.26" y="218.44"/>
 <pinref part="PAD45" gate="G$1" pin="P$1"/>
 <wire x1="302.26" y1="218.44" x2="304.8" y2="218.44" width="0.1524" layer="91"/>
-<label x="279.4" y="218.44" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="279.4" y="218.44" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B_GND" class="0">
 <segment>
-<label x="45.72" y="203.2" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="203.2" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="203.2" x2="48.26" y2="203.2" width="0.1524" layer="91"/>
 <pinref part="PAD32" gate="G$1" pin="P$1"/>
 </segment>
@@ -5226,24 +5287,24 @@ when running on discharged 8S battery</text>
 <pinref part="Q2" gate="T2" pin="S"/>
 <wire x1="302.26" y1="205.74" x2="302.26" y2="195.58" width="0.1524" layer="91"/>
 <junction x="302.26" y="195.58"/>
-<label x="279.4" y="195.58" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="279.4" y="195.58" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A_GATE_HIGH" class="1">
 <segment>
-<label x="45.72" y="220.98" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="220.98" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="220.98" x2="48.26" y2="220.98" width="0.1524" layer="91"/>
 <pinref part="PAD25" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R1" gate="G$1" pin="1"/>
 <wire x1="213.36" y1="228.6" x2="215.9" y2="228.6" width="0.1524" layer="91"/>
-<label x="213.36" y="228.6" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="213.36" y="228.6" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A" class="1">
 <segment>
-<label x="45.72" y="218.44" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="218.44" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="218.44" x2="48.26" y2="218.44" width="0.1524" layer="91"/>
 <pinref part="PAD26" gate="G$1" pin="P$1"/>
 </segment>
@@ -5256,74 +5317,74 @@ when running on discharged 8S battery</text>
 <wire x1="236.22" y1="220.98" x2="213.36" y2="220.98" width="0.1524" layer="91"/>
 <pinref part="Q1" gate="T2" pin="D"/>
 <pinref part="Q1" gate="T1" pin="S"/>
-<label x="213.36" y="220.98" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="213.36" y="220.98" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B_GATE_HIGH" class="1">
 <segment>
-<label x="45.72" y="210.82" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="210.82" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="210.82" x2="48.26" y2="210.82" width="0.1524" layer="91"/>
 <pinref part="PAD29" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R8" gate="G$1" pin="1"/>
 <wire x1="281.94" y1="226.06" x2="279.4" y2="226.06" width="0.1524" layer="91"/>
-<label x="279.4" y="226.06" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="279.4" y="226.06" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B_GATE_LOW" class="0">
 <segment>
-<label x="45.72" y="205.74" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="205.74" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="205.74" x2="48.26" y2="205.74" width="0.1524" layer="91"/>
 <pinref part="PAD31" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R9" gate="G$1" pin="1"/>
 <wire x1="281.94" y1="210.82" x2="279.4" y2="210.82" width="0.1524" layer="91"/>
-<label x="279.4" y="210.82" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="279.4" y="210.82" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A_GATE_LOW" class="0">
 <segment>
-<label x="45.72" y="215.9" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="215.9" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="215.9" x2="48.26" y2="215.9" width="0.1524" layer="91"/>
 <pinref part="PAD27" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R2" gate="G$1" pin="1"/>
 <wire x1="213.36" y1="213.36" x2="215.9" y2="213.36" width="0.1524" layer="91"/>
-<label x="213.36" y="213.36" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="213.36" y="213.36" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B_CURRENT_SHUNT_N" class="0">
 <segment>
 <wire x1="48.26" y1="177.8" x2="45.72" y2="177.8" width="0.1524" layer="91"/>
-<label x="45.72" y="177.8" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="177.8" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD39" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R10" gate="G$1" pin="S1"/>
 <wire x1="289.56" y1="190.5" x2="299.72" y2="190.5" width="0.1524" layer="91"/>
 <wire x1="299.72" y1="190.5" x2="299.72" y2="187.96" width="0.1524" layer="91"/>
-<label x="289.56" y="190.5" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="289.56" y="190.5" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_B_CURRENT_SHUNT_P" class="0">
 <segment>
 <wire x1="48.26" y1="175.26" x2="45.72" y2="175.26" width="0.1524" layer="91"/>
-<label x="45.72" y="175.26" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="175.26" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD40" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <wire x1="289.56" y1="175.26" x2="299.72" y2="175.26" width="0.1524" layer="91"/>
 <pinref part="R10" gate="G$1" pin="S2"/>
 <wire x1="299.72" y1="177.8" x2="299.72" y2="175.26" width="0.1524" layer="91"/>
-<label x="289.56" y="175.26" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="289.56" y="175.26" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A_CURRENT_SHUNT_N" class="0">
 <segment>
-<label x="45.72" y="190.5" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="190.5" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="190.5" x2="48.26" y2="190.5" width="0.1524" layer="91"/>
 <pinref part="PAD37" gate="G$1" pin="P$1"/>
 </segment>
@@ -5331,12 +5392,12 @@ when running on discharged 8S battery</text>
 <pinref part="R4" gate="G$1" pin="S1"/>
 <wire x1="223.52" y1="193.04" x2="233.68" y2="193.04" width="0.1524" layer="91"/>
 <wire x1="233.68" y1="193.04" x2="233.68" y2="190.5" width="0.1524" layer="91"/>
-<label x="223.52" y="193.04" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="223.52" y="193.04" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A_CURRENT_SHUNT_P" class="0">
 <segment>
-<label x="45.72" y="187.96" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="187.96" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="187.96" x2="48.26" y2="187.96" width="0.1524" layer="91"/>
 <pinref part="PAD38" gate="G$1" pin="P$1"/>
 </segment>
@@ -5344,32 +5405,32 @@ when running on discharged 8S battery</text>
 <wire x1="223.52" y1="177.8" x2="233.68" y2="177.8" width="0.1524" layer="91"/>
 <pinref part="R4" gate="G$1" pin="S2"/>
 <wire x1="233.68" y1="180.34" x2="233.68" y2="177.8" width="0.1524" layer="91"/>
-<label x="223.52" y="177.8" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="223.52" y="177.8" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="USART_TX" class="0">
 <segment>
 <wire x1="45.72" y1="93.98" x2="43.18" y2="93.98" width="0.1524" layer="91"/>
-<label x="43.18" y="93.98" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="93.98" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD19" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="USART_RX" class="0">
 <segment>
 <wire x1="45.72" y1="91.44" x2="43.18" y2="91.44" width="0.1524" layer="91"/>
-<label x="43.18" y="91.44" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="91.44" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD20" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="CAN1_RX" class="0">
 <segment>
 <wire x1="45.72" y1="157.48" x2="40.64" y2="157.48" width="0.1524" layer="91"/>
-<label x="40.64" y="157.48" size="1.27" layer="95" rot="MR0" xref="yes"/>
+<label x="40.64" y="157.48" size="1.27" layer="95" font="vector" rot="MR0" xref="yes"/>
 <pinref part="PAD2" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <wire x1="320.04" y1="119.38" x2="312.42" y2="119.38" width="0.1524" layer="91"/>
-<label x="312.42" y="119.38" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="312.42" y="119.38" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="IC3" gate="G$1" pin="RXD"/>
 </segment>
 </net>
@@ -5384,7 +5445,7 @@ when running on discharged 8S battery</text>
 <pinref part="C10" gate="G$1" pin="1"/>
 <wire x1="320.04" y1="121.92" x2="314.96" y2="121.92" width="0.1524" layer="91"/>
 <wire x1="314.96" y1="121.92" x2="299.72" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="299.72" y1="121.92" x2="299.72" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="299.72" y1="121.92" x2="299.72" y2="116.84" width="0.1524" layer="91"/>
 <wire x1="299.72" y1="121.92" x2="299.72" y2="124.46" width="0.1524" layer="91"/>
 <junction x="299.72" y="121.92"/>
 <pinref part="+P12" gate="G$1" pin="VDD_5V"/>
@@ -5408,22 +5469,22 @@ when running on discharged 8S battery</text>
 <segment>
 <pinref part="LED4" gate="G$1" pin="A"/>
 <pinref part="+P11" gate="G$1" pin="VDD_5V"/>
-<wire x1="271.78" y1="124.46" x2="271.78" y2="127" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="119.38" x2="274.32" y2="121.92" width="0.1524" layer="91"/>
 <pinref part="LED3" gate="G$1" pin="A"/>
-<wire x1="271.78" y1="127" x2="271.78" y2="132.08" width="0.1524" layer="91"/>
-<wire x1="248.92" y1="124.46" x2="248.92" y2="127" width="0.1524" layer="91"/>
-<wire x1="248.92" y1="127" x2="271.78" y2="127" width="0.1524" layer="91"/>
-<junction x="271.78" y="127"/>
+<wire x1="274.32" y1="121.92" x2="274.32" y2="127" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="119.38" x2="251.46" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="121.92" x2="274.32" y2="121.92" width="0.1524" layer="91"/>
+<junction x="274.32" y="121.92"/>
 </segment>
 <segment>
 <pinref part="+P9" gate="G$1" pin="VDD_5V"/>
 <pinref part="LED2" gate="G$1" pin="A"/>
-<wire x1="231.14" y1="124.46" x2="231.14" y2="127" width="0.1524" layer="91"/>
 <pinref part="LED1" gate="G$1" pin="A"/>
-<wire x1="231.14" y1="127" x2="231.14" y2="132.08" width="0.1524" layer="91"/>
-<wire x1="223.52" y1="124.46" x2="223.52" y2="127" width="0.1524" layer="91"/>
-<wire x1="223.52" y1="127" x2="231.14" y2="127" width="0.1524" layer="91"/>
-<junction x="231.14" y="127"/>
+<wire x1="233.68" y1="119.38" x2="233.68" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="233.68" y1="121.92" x2="233.68" y2="127" width="0.1524" layer="91"/>
+<wire x1="226.06" y1="119.38" x2="226.06" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="226.06" y1="121.92" x2="233.68" y2="121.92" width="0.1524" layer="91"/>
+<junction x="233.68" y="121.92"/>
 </segment>
 <segment>
 <pinref part="IC1" gate="G$1" pin="VCC"/>
@@ -5438,19 +5499,19 @@ when running on discharged 8S battery</text>
 <net name="CAN1_LED" class="0">
 <segment>
 <wire x1="45.72" y1="134.62" x2="43.18" y2="134.62" width="0.1524" layer="91"/>
-<label x="43.18" y="134.62" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="134.62" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD6" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R3" gate="G$1" pin="1"/>
-<wire x1="231.14" y1="99.06" x2="231.14" y2="101.6" width="0.1524" layer="91"/>
-<label x="231.14" y="99.06" size="1.27" layer="95" rot="R270" xref="yes"/>
+<wire x1="233.68" y1="93.98" x2="233.68" y2="96.52" width="0.1524" layer="91"/>
+<label x="233.68" y="93.98" size="1.27" layer="95" font="vector" rot="R270" xref="yes"/>
 </segment>
 </net>
 <net name="CAN2_LED" class="0">
 <segment>
 <wire x1="45.72" y1="137.16" x2="43.18" y2="137.16" width="0.1524" layer="91"/>
-<label x="43.18" y="137.16" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="137.16" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD5" gate="G$1" pin="P$1"/>
 </segment>
 </net>
@@ -5464,27 +5525,27 @@ when running on discharged 8S battery</text>
 <net name="USB+" class="0">
 <segment>
 <wire x1="45.72" y1="132.08" x2="43.18" y2="132.08" width="0.1524" layer="91"/>
-<label x="43.18" y="132.08" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="132.08" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD7" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="USB-" class="0">
 <segment>
 <wire x1="45.72" y1="129.54" x2="43.18" y2="129.54" width="0.1524" layer="91"/>
-<label x="43.18" y="129.54" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="129.54" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD8" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="USB_VBUS" class="0">
 <segment>
 <wire x1="45.72" y1="127" x2="43.18" y2="127" width="0.1524" layer="91"/>
-<label x="43.18" y="127" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="127" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD9" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="POWER_ENABLE_IN" class="0">
 <segment>
-<label x="43.18" y="96.52" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="96.52" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="96.52" x2="43.18" y2="96.52" width="0.1524" layer="91"/>
 <pinref part="PAD18" gate="G$1" pin="P$1"/>
 </segment>
@@ -5492,39 +5553,39 @@ when running on discharged 8S battery</text>
 <net name="GPIO2" class="0">
 <segment>
 <wire x1="45.72" y1="111.76" x2="43.18" y2="111.76" width="0.1524" layer="91"/>
-<label x="43.18" y="111.76" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="111.76" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD15" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="EN_GATE_OUT" class="0">
 <segment>
 <wire x1="43.18" y1="109.22" x2="45.72" y2="109.22" width="0.1524" layer="91"/>
-<label x="43.18" y="109.22" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="109.22" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD16" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="GAIN_OUT" class="0">
 <segment>
 <wire x1="43.18" y1="106.68" x2="45.72" y2="106.68" width="0.1524" layer="91"/>
-<label x="43.18" y="106.68" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="106.68" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD17" gate="G$1" pin="P$1"/>
 </segment>
 </net>
 <net name="BEC_ENABLE_OUT" class="0">
 <segment>
 <wire x1="45.72" y1="88.9" x2="43.18" y2="88.9" width="0.1524" layer="91"/>
-<label x="43.18" y="88.9" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="43.18" y="88.9" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD21" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="IC2" gate="G$1" pin="EN"/>
 <wire x1="314.96" y1="91.44" x2="312.42" y2="91.44" width="0.1524" layer="91"/>
-<label x="312.42" y="91.44" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="312.42" y="91.44" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_C_GND" class="0">
 <segment>
-<label x="45.72" y="193.04" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="193.04" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="193.04" x2="48.26" y2="193.04" width="0.1524" layer="91"/>
 <pinref part="PAD36" gate="G$1" pin="P$1"/>
 </segment>
@@ -5532,24 +5593,24 @@ when running on discharged 8S battery</text>
 <pinref part="S1" gate="G$1" pin="IN"/>
 <wire x1="355.6" y1="195.58" x2="355.6" y2="193.04" width="0.1524" layer="91"/>
 <wire x1="355.6" y1="195.58" x2="342.9" y2="195.58" width="0.1524" layer="91"/>
-<label x="342.9" y="195.58" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="342.9" y="195.58" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_C_GATE_LOW" class="0">
 <segment>
-<label x="45.72" y="195.58" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="195.58" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="195.58" x2="48.26" y2="195.58" width="0.1524" layer="91"/>
 <pinref part="PAD35" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R12" gate="G$1" pin="1"/>
 <wire x1="342.9" y1="210.82" x2="340.36" y2="210.82" width="0.1524" layer="91"/>
-<label x="340.36" y="210.82" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="340.36" y="210.82" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_C" class="1">
 <segment>
-<label x="45.72" y="198.12" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="198.12" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="198.12" x2="48.26" y2="198.12" width="0.1524" layer="91"/>
 <pinref part="PAD34" gate="G$1" pin="P$1"/>
 </segment>
@@ -5562,19 +5623,19 @@ when running on discharged 8S battery</text>
 <junction x="363.22" y="218.44"/>
 <pinref part="Q3" gate="T1" pin="S"/>
 <wire x1="363.22" y1="220.98" x2="363.22" y2="218.44" width="0.1524" layer="91"/>
-<label x="340.36" y="218.44" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="340.36" y="218.44" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_C_GATE_HIGH" class="1">
 <segment>
-<label x="45.72" y="200.66" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="200.66" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <wire x1="45.72" y1="200.66" x2="48.26" y2="200.66" width="0.1524" layer="91"/>
 <pinref part="PAD33" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="R11" gate="G$1" pin="1"/>
 <wire x1="342.9" y1="226.06" x2="340.36" y2="226.06" width="0.1524" layer="91"/>
-<label x="340.36" y="226.06" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="340.36" y="226.06" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="GND" class="0">
@@ -5597,13 +5658,11 @@ when running on discharged 8S battery</text>
 <wire x1="317.5" y1="124.46" x2="317.5" y2="106.68" width="0.1524" layer="91"/>
 <pinref part="IC3" gate="G$1" pin="GND"/>
 <pinref part="C10" gate="G$1" pin="2"/>
-<wire x1="317.5" y1="106.68" x2="317.5" y2="104.14" width="0.1524" layer="91"/>
-<wire x1="299.72" y1="109.22" x2="299.72" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="299.72" y1="109.22" x2="299.72" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="299.72" y1="111.76" x2="299.72" y2="106.68" width="0.1524" layer="91"/>
 <wire x1="299.72" y1="106.68" x2="317.5" y2="106.68" width="0.1524" layer="91"/>
 <junction x="317.5" y="106.68"/>
 <pinref part="GND14" gate="1" pin="GND"/>
-<wire x1="317.5" y1="101.6" x2="317.5" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="317.5" y1="101.6" x2="317.5" y2="106.68" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="C11" gate="G$1" pin="2"/>
@@ -5710,25 +5769,25 @@ when running on discharged 8S battery</text>
 <net name="N$58" class="0">
 <segment>
 <pinref part="LED4" gate="G$1" pin="R"/>
-<wire x1="276.86" y1="109.22" x2="276.86" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="279.4" y1="104.14" x2="279.4" y2="101.6" width="0.1524" layer="91"/>
 <pinref part="R7" gate="G$1" pin="1"/>
 <pinref part="LED3" gate="G$1" pin="R"/>
-<wire x1="276.86" y1="106.68" x2="276.86" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="254" y1="109.22" x2="254" y2="106.68" width="0.1524" layer="91"/>
-<wire x1="254" y1="106.68" x2="276.86" y2="106.68" width="0.1524" layer="91"/>
-<junction x="276.86" y="106.68"/>
+<wire x1="279.4" y1="101.6" x2="279.4" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="256.54" y1="104.14" x2="256.54" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="256.54" y1="101.6" x2="279.4" y2="101.6" width="0.1524" layer="91"/>
+<junction x="279.4" y="101.6"/>
 </segment>
 </net>
 <net name="N$60" class="0">
 <segment>
 <pinref part="LED4" gate="G$1" pin="B"/>
-<wire x1="266.7" y1="109.22" x2="266.7" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="269.24" y1="104.14" x2="269.24" y2="96.52" width="0.1524" layer="91"/>
 <pinref part="R5" gate="G$1" pin="1"/>
 <pinref part="LED3" gate="G$1" pin="B"/>
-<wire x1="266.7" y1="101.6" x2="266.7" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="243.84" y1="109.22" x2="243.84" y2="101.6" width="0.1524" layer="91"/>
-<wire x1="243.84" y1="101.6" x2="266.7" y2="101.6" width="0.1524" layer="91"/>
-<junction x="266.7" y="101.6"/>
+<wire x1="269.24" y1="96.52" x2="269.24" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="246.38" y1="104.14" x2="246.38" y2="96.52" width="0.1524" layer="91"/>
+<wire x1="246.38" y1="96.52" x2="269.24" y2="96.52" width="0.1524" layer="91"/>
+<junction x="269.24" y="96.52"/>
 </segment>
 </net>
 <net name="TEMPERATURE_SENSOR" class="0">
@@ -5736,14 +5795,14 @@ when running on discharged 8S battery</text>
 <pinref part="IC1" gate="G$1" pin="OUT"/>
 <wire x1="175.26" y1="187.96" x2="162.56" y2="187.96" width="0.1524" layer="91"/>
 <wire x1="160.02" y1="187.96" x2="162.56" y2="187.96" width="0.1524" layer="91"/>
-<label x="160.02" y="187.96" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="160.02" y="187.96" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="C4" gate="G$1" pin="1"/>
 <wire x1="162.56" y1="185.42" x2="162.56" y2="187.96" width="0.1524" layer="91"/>
 <junction x="162.56" y="187.96"/>
 </segment>
 <segment>
 <wire x1="48.26" y1="172.72" x2="45.72" y2="172.72" width="0.1524" layer="91"/>
-<label x="45.72" y="172.72" size="1.27" layer="95" rot="R180" xref="yes"/>
+<label x="45.72" y="172.72" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 <pinref part="PAD41" gate="G$1" pin="P$1"/>
 </segment>
 </net>
@@ -5790,12 +5849,12 @@ when running on discharged 8S battery</text>
 </segment>
 <segment>
 <pinref part="D1" gate="G$1" pin="A"/>
-<wire x1="119.38" y1="223.52" x2="116.84" y2="223.52" width="0.1524" layer="91"/>
+<wire x1="93.98" y1="231.14" x2="91.44" y2="231.14" width="0.1524" layer="91"/>
 <pinref part="GND2" gate="G$1" pin="PGND"/>
-<wire x1="119.38" y1="220.98" x2="119.38" y2="223.52" width="0.1524" layer="91"/>
-<junction x="119.38" y="223.52"/>
-<junction x="119.38" y="223.52"/>
-<wire x1="119.38" y1="223.52" x2="119.38" y2="226.06" width="0.1524" layer="91"/>
+<wire x1="93.98" y1="228.6" x2="93.98" y2="231.14" width="0.1524" layer="91"/>
+<junction x="93.98" y="231.14"/>
+<junction x="93.98" y="231.14"/>
+<wire x1="93.98" y1="231.14" x2="93.98" y2="233.68" width="0.1524" layer="91"/>
 <pinref part="PAD43" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
@@ -5888,13 +5947,13 @@ when running on discharged 8S battery</text>
 </segment>
 <segment>
 <pinref part="D1" gate="G$1" pin="C"/>
-<wire x1="116.84" y1="233.68" x2="119.38" y2="233.68" width="0.1524" layer="91"/>
-<junction x="119.38" y="233.68"/>
-<junction x="119.38" y="233.68"/>
-<wire x1="119.38" y1="233.68" x2="119.38" y2="231.14" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="241.3" x2="93.98" y2="241.3" width="0.1524" layer="91"/>
+<junction x="93.98" y="241.3"/>
+<junction x="93.98" y="241.3"/>
+<wire x1="93.98" y1="241.3" x2="93.98" y2="238.76" width="0.1524" layer="91"/>
 <pinref part="PAD42" gate="G$1" pin="P$1"/>
 <pinref part="+P3" gate="G$1" pin="VDC"/>
-<wire x1="119.38" y1="236.22" x2="119.38" y2="233.68" width="0.1524" layer="91"/>
+<wire x1="93.98" y1="243.84" x2="93.98" y2="241.3" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <wire x1="48.26" y1="231.14" x2="40.64" y2="231.14" width="0.1524" layer="91"/>
@@ -5907,12 +5966,12 @@ when running on discharged 8S battery</text>
 <segment>
 <pinref part="R3" gate="G$1" pin="2"/>
 <pinref part="LED2" gate="G$1" pin="C"/>
-<wire x1="231.14" y1="111.76" x2="231.14" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="233.68" y1="106.68" x2="233.68" y2="109.22" width="0.1524" layer="91"/>
 <pinref part="LED1" gate="G$1" pin="C"/>
-<wire x1="231.14" y1="114.3" x2="231.14" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="223.52" y1="116.84" x2="223.52" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="223.52" y1="114.3" x2="231.14" y2="114.3" width="0.1524" layer="91"/>
-<junction x="231.14" y="114.3"/>
+<wire x1="233.68" y1="109.22" x2="233.68" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="226.06" y1="111.76" x2="226.06" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="226.06" y1="109.22" x2="233.68" y2="109.22" width="0.1524" layer="91"/>
+<junction x="233.68" y="109.22"/>
 </segment>
 </net>
 <net name="N$22" class="0">
@@ -5988,14 +6047,13 @@ when running on discharged 8S battery</text>
 <net name="N$4" class="0">
 <segment>
 <pinref part="LED3" gate="G$1" pin="G"/>
-<wire x1="248.92" y1="106.68" x2="248.92" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="248.92" y1="106.68" x2="248.92" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="104.14" x2="251.46" y2="99.06" width="0.1524" layer="91"/>
 <pinref part="LED4" gate="G$1" pin="G"/>
-<wire x1="271.78" y1="109.22" x2="271.78" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="104.14" x2="274.32" y2="99.06" width="0.1524" layer="91"/>
 <pinref part="R6" gate="G$1" pin="1"/>
-<wire x1="271.78" y1="104.14" x2="271.78" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="248.92" y1="104.14" x2="271.78" y2="104.14" width="0.1524" layer="91"/>
-<junction x="271.78" y="104.14"/>
+<wire x1="274.32" y1="99.06" x2="274.32" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="251.46" y1="99.06" x2="274.32" y2="99.06" width="0.1524" layer="91"/>
+<junction x="274.32" y="99.06"/>
 </segment>
 </net>
 </nets>
@@ -6006,7 +6064,8 @@ when running on discharged 8S battery</text>
 <text x="7.62" y="124.46" size="1.778" layer="97" font="vector" align="top-left">-Current shunts replaced (5 mOhms replaced with 10 mOhms)-
 -Overcurrent protection added. Itrip is ~35 A
 -RCPWM th connector replaced with smd solder pads
--Some design notes added to the schematic</text>
+-Some design notes added to the schematic
+-TVS diode (D1) replaced with one that has lower breaksdown voltage</text>
 </plain>
 <instances>
 <instance part="FRAME2" gate="G$1" x="0" y="0" smashed="yes">

--- a/bloxa.sch
+++ b/bloxa.sch
@@ -198,6 +198,25 @@
 <text x="343.916" y="4.953" size="2.54" layer="94">Sheet:</text>
 <frame x1="0" y1="0" x2="387.35" y2="260.35" columns="8" rows="5" layer="94"/>
 </symbol>
+<symbol name="A5L-LOC" urn="urn:adsk.eagle:symbol:13879/1" library_version="1">
+<wire x1="85.09" y1="3.81" x2="85.09" y2="24.13" width="0.1016" layer="94"/>
+<wire x1="85.09" y1="24.13" x2="139.065" y2="24.13" width="0.1016" layer="94"/>
+<wire x1="139.065" y1="24.13" x2="180.34" y2="24.13" width="0.1016" layer="94"/>
+<wire x1="170.18" y1="3.81" x2="170.18" y2="8.89" width="0.1016" layer="94"/>
+<wire x1="170.18" y1="8.89" x2="180.34" y2="8.89" width="0.1016" layer="94"/>
+<wire x1="170.18" y1="8.89" x2="139.065" y2="8.89" width="0.1016" layer="94"/>
+<wire x1="139.065" y1="8.89" x2="139.065" y2="3.81" width="0.1016" layer="94"/>
+<wire x1="139.065" y1="8.89" x2="139.065" y2="13.97" width="0.1016" layer="94"/>
+<wire x1="139.065" y1="13.97" x2="180.34" y2="13.97" width="0.1016" layer="94"/>
+<wire x1="139.065" y1="13.97" x2="139.065" y2="19.05" width="0.1016" layer="94"/>
+<wire x1="139.065" y1="19.05" x2="180.34" y2="19.05" width="0.1016" layer="94"/>
+<wire x1="139.065" y1="19.05" x2="139.065" y2="24.13" width="0.1016" layer="94"/>
+<text x="140.97" y="15.24" size="2.54" layer="94">&gt;DRAWING_NAME</text>
+<text x="140.97" y="10.16" size="2.286" layer="94">&gt;LAST_DATE_TIME</text>
+<text x="154.305" y="5.08" size="2.54" layer="94">&gt;SHEET</text>
+<text x="140.716" y="4.953" size="2.54" layer="94">Sheet:</text>
+<frame x1="0" y1="0" x2="184.15" y2="133.35" columns="4" rows="4" layer="94"/>
+</symbol>
 </symbols>
 <devicesets>
 <deviceset name="A3L-LOC" urn="urn:adsk.eagle:component:13942/1" prefix="FRAME" uservalue="yes" library_version="1">
@@ -205,6 +224,19 @@
 DIN A3, landscape with location and doc. field</description>
 <gates>
 <gate name="G$1" symbol="A3L-LOC" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="A5L-LOC" urn="urn:adsk.eagle:component:13933/1" prefix="FRAME" uservalue="yes" library_version="1">
+<description>A5L LOC</description>
+<gates>
+<gate name="G$1" symbol="A5L-LOC" x="0" y="0"/>
 </gates>
 <devices>
 <device name="">
@@ -4216,7 +4248,7 @@ http://www.bccomponents.com/</description>
 <attributes>
 </attributes>
 <variantdefs>
-<variantdef name="Basic" current="yes"/>
+<variantdef name="Basic"/>
 <variantdef name="nocaps"/>
 </variantdefs>
 <classes>
@@ -4482,6 +4514,7 @@ http://www.bccomponents.com/</description>
 <part name="GND25" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 <part name="PAD47" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-S-1.5" package3d_urn="urn:adsk.eagle:package:15477730/1"/>
 <part name="PAD48" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-S-1.5" package3d_urn="urn:adsk.eagle:package:15477730/1"/>
+<part name="FRAME2" library="frames" library_urn="urn:adsk.eagle:library:229" deviceset="A5L-LOC" device=""/>
 </parts>
 <sheets>
 <sheet>
@@ -5973,6 +6006,26 @@ https://a360.co/3asTElW</text>
 <wire x1="17.78" y1="45.72" x2="96.52" y2="45.72" width="0.1524" layer="91"/>
 </segment>
 </net>
+</nets>
+</sheet>
+<sheet>
+<description>changelog</description>
+<plain>
+<text x="7.62" y="101.6" size="1.778" layer="91" font="vector" align="center-left">-Current shunts replaced (5 mOhms replaced with 10 mOhms)-
+-Overcurrent protection added. Itrip is ~35 A
+-RCPWM th connector replaced with smd solder pads
+-Some design notes added to the schematic</text>
+</plain>
+<instances>
+<instance part="FRAME2" gate="G$1" x="0" y="0" smashed="yes">
+<attribute name="DRAWING_NAME" x="140.97" y="15.24" size="2.54" layer="94"/>
+<attribute name="LAST_DATE_TIME" x="140.97" y="10.16" size="2.286" layer="94"/>
+<attribute name="SHEET" x="154.305" y="5.08" size="2.54" layer="94"/>
+</instance>
+</instances>
+<busses>
+</busses>
+<nets>
 </nets>
 </sheet>
 </sheets>

--- a/bloxa.sch
+++ b/bloxa.sch
@@ -4216,7 +4216,7 @@ http://www.bccomponents.com/</description>
 <attributes>
 </attributes>
 <variantdefs>
-<variantdef name="Basic"/>
+<variantdef name="Basic" current="yes"/>
 <variantdef name="nocaps"/>
 </variantdefs>
 <classes>
@@ -4500,7 +4500,7 @@ http://www.bccomponents.com/</description>
 <wire x1="220.98" y1="69.85" x2="285.75" y2="69.85" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="285.75" y1="142.24" x2="220.98" y2="142.24" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="220.98" y1="142.24" x2="220.98" y2="69.85" width="0.1524" layer="97" style="shortdash"/>
-<text x="228.6" y="144.78" size="2.54" layer="97" font="vector" align="center-left">INDICATION</text>
+<text x="241.3" y="137.16" size="2.54" layer="97" font="vector" align="center-left">INDICATION</text>
 <text x="132.08" y="248.92" size="1.27" layer="97">The minimum specific bulk capacitance is 20 μF/A 
 (e.g. an ESC rated for 20 A DC requires at least 400 μF).</text>
 <text x="193.04" y="236.22" size="2.54" layer="97">PHASE_A</text>
@@ -4525,43 +4525,44 @@ http://www.bccomponents.com/</description>
 <text x="134.62" y="213.36" size="2.54" layer="97">Capacitor battery</text>
 <text x="134.62" y="208.28" size="1.27" layer="97">These capacitors should be placed 
 as close as possible to the power transistors.</text>
-<text x="134.62" y="198.12" size="1.778" layer="97">Temperature sensor</text>
-<text x="134.62" y="160.02" size="2.54" layer="97">Place close to power mosfets</text>
-<text x="233.68" y="38.1" size="1.778" layer="91">https://www.digikey.com/product-detail/en/united-chemi-con/EKZN500ELL181MH20D/565-4066-ND/4843876</text>
+<text x="134.62" y="200.66" size="3.81" layer="97">Temperature sensor</text>
+<text x="134.62" y="165.1" size="2.54" layer="97">Place close to power mosfets</text>
 <wire x1="289.56" y1="134.62" x2="289.56" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="289.56" y1="63.5" x2="375.92" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="375.92" y1="63.5" x2="375.92" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="375.92" y1="134.62" x2="289.56" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
-<text x="20.32" y="30.48" size="1.27" layer="91" font="vector" ratio="15" align="center">DC power, W</text>
-<text x="38.1" y="30.48" size="1.27" layer="91" font="vector" ratio="15" align="center">Phase current, I</text>
-<text x="58.42" y="30.48" size="1.27" layer="91" font="vector" ratio="15" align="center">Total losses, W</text>
-<text x="81.28" y="30.48" size="1.27" layer="91" font="vector" ratio="15" align="center">Efficiency, %</text>
-<text x="20.32" y="25.4" size="1.27" layer="91" font="vector" ratio="15" align="center">100</text>
-<text x="20.32" y="22.86" size="1.27" layer="91" font="vector" ratio="15" align="center">150</text>
-<text x="20.32" y="20.32" size="1.27" layer="91" font="vector" ratio="15" align="center">200</text>
-<text x="20.32" y="17.78" size="1.27" layer="91" font="vector" ratio="15" align="center">250</text>
-<text x="20.32" y="15.24" size="1.27" layer="91" font="vector" ratio="15" align="center">300</text>
-<text x="50.8" y="10.16" size="1.27" layer="91" font="vector" ratio="15" align="center">The table is valid for 26.4 V supply voltage which is discharched 8S battery</text>
-<text x="38.1" y="25.4" size="1.27" layer="91" font="vector" ratio="15" align="center">4.8</text>
-<text x="58.42" y="25.4" size="1.27" layer="91" font="vector" ratio="15" align="center">1.7</text>
-<text x="81.28" y="25.4" size="1.27" layer="91" font="vector" ratio="15" align="center">98.3</text>
-<text x="38.1" y="22.86" size="1.27" layer="91" font="vector" ratio="15" align="center">7.2</text>
-<text x="58.42" y="22.86" size="1.27" layer="91" font="vector" ratio="15" align="center">3</text>
-<text x="81.28" y="22.86" size="1.27" layer="91" font="vector" ratio="15" align="center">98</text>
-<text x="38.1" y="20.32" size="1.27" layer="91" font="vector" ratio="15" align="center">9.6</text>
-<text x="58.42" y="20.32" size="1.27" layer="91" font="vector" ratio="15" align="center">4.5</text>
-<text x="81.28" y="20.32" size="1.27" layer="91" font="vector" ratio="15" align="center">97.7</text>
-<text x="38.1" y="17.78" size="1.27" layer="91" font="vector" ratio="15" align="center">12</text>
-<text x="58.42" y="17.78" size="1.27" layer="91" font="vector" ratio="15" align="center">6.3</text>
-<text x="81.28" y="17.78" size="1.27" layer="91" font="vector" ratio="15" align="center">97.5</text>
-<text x="38.1" y="15.24" size="1.27" layer="91" font="vector" ratio="15" align="center">14.4</text>
-<text x="58.42" y="15.24" size="1.27" layer="91" font="vector" ratio="15" align="center">8.4</text>
-<text x="81.28" y="15.24" size="1.27" layer="91" font="vector" ratio="15" align="center">97.2</text>
-<text x="53.34" y="35.56" size="1.27" layer="91" font="vector" ratio="15" align="center">Power losses for different power levels</text>
+<text x="25.4" y="48.26" size="1.27" layer="91" font="vector" ratio="15" align="center">DC power, W</text>
+<text x="43.18" y="48.26" size="1.27" layer="91" font="vector" ratio="15" align="center">Phase current, I</text>
+<text x="63.5" y="48.26" size="1.27" layer="91" font="vector" ratio="15" align="center">Total losses, W</text>
+<text x="86.36" y="48.26" size="1.27" layer="91" font="vector" ratio="15" align="center">Efficiency, %</text>
+<text x="25.4" y="43.18" size="1.27" layer="91" font="vector" ratio="15" align="center">100</text>
+<text x="25.4" y="40.64" size="1.27" layer="91" font="vector" ratio="15" align="center">150</text>
+<text x="25.4" y="38.1" size="1.27" layer="91" font="vector" ratio="15" align="center">200</text>
+<text x="25.4" y="35.56" size="1.27" layer="91" font="vector" ratio="15" align="center">250</text>
+<text x="25.4" y="33.02" size="1.27" layer="91" font="vector" ratio="15" align="center">300</text>
+<text x="55.88" y="27.94" size="1.27" layer="91" font="vector" ratio="15" align="center">The table is valid for 26.4 V supply voltage which is discharched 8S battery</text>
+<text x="43.18" y="43.18" size="1.27" layer="91" font="vector" ratio="15" align="center">4.8</text>
+<text x="63.5" y="43.18" size="1.27" layer="91" font="vector" ratio="15" align="center">1.7</text>
+<text x="86.36" y="43.18" size="1.27" layer="91" font="vector" ratio="15" align="center">98.3</text>
+<text x="43.18" y="40.64" size="1.27" layer="91" font="vector" ratio="15" align="center">7.2</text>
+<text x="63.5" y="40.64" size="1.27" layer="91" font="vector" ratio="15" align="center">3</text>
+<text x="86.36" y="40.64" size="1.27" layer="91" font="vector" ratio="15" align="center">98</text>
+<text x="43.18" y="38.1" size="1.27" layer="91" font="vector" ratio="15" align="center">9.6</text>
+<text x="63.5" y="38.1" size="1.27" layer="91" font="vector" ratio="15" align="center">4.5</text>
+<text x="86.36" y="38.1" size="1.27" layer="91" font="vector" ratio="15" align="center">97.7</text>
+<text x="43.18" y="35.56" size="1.27" layer="91" font="vector" ratio="15" align="center">12</text>
+<text x="63.5" y="35.56" size="1.27" layer="91" font="vector" ratio="15" align="center">6.3</text>
+<text x="86.36" y="35.56" size="1.27" layer="91" font="vector" ratio="15" align="center">97.5</text>
+<text x="43.18" y="33.02" size="1.27" layer="91" font="vector" ratio="15" align="center">14.4</text>
+<text x="63.5" y="33.02" size="1.27" layer="91" font="vector" ratio="15" align="center">8.4</text>
+<text x="86.36" y="33.02" size="1.27" layer="91" font="vector" ratio="15" align="center">97.2</text>
+<text x="58.42" y="53.34" size="1.27" layer="91" font="vector" ratio="15" align="center">Power losses for different power levels</text>
 <text x="63.5" y="111.76" size="1.778" layer="91" font="vector" ratio="15" align="center-left">R14 sets overcurrent protection trip level. 
 680R sets ir arount 35A, which is 2.5 times 
 higher than maximum phase current for 300W DC power 
 when running on discharged 8S battery</text>
+<text x="88.9" y="246.38" size="1.778" layer="91" font="vector" ratio="15" align="center">For 3d model check this link
+https://a360.co/3asTElW</text>
 </plain>
 <instances>
 <instance part="+P2" gate="G$1" x="45.72" y="238.76" smashed="yes">
@@ -5954,22 +5955,22 @@ when running on discharged 8S battery</text>
 </net>
 <net name="N$1" class="0">
 <segment>
-<wire x1="12.7" y1="33.02" x2="12.7" y2="27.94" width="0.1524" layer="91"/>
-<wire x1="12.7" y1="27.94" x2="12.7" y2="12.7" width="0.1524" layer="91"/>
-<wire x1="12.7" y1="12.7" x2="27.94" y2="12.7" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="12.7" x2="48.26" y2="12.7" width="0.1524" layer="91"/>
-<wire x1="48.26" y1="12.7" x2="71.12" y2="12.7" width="0.1524" layer="91"/>
-<wire x1="71.12" y1="12.7" x2="91.44" y2="12.7" width="0.1524" layer="91"/>
-<wire x1="91.44" y1="33.02" x2="71.12" y2="33.02" width="0.1524" layer="91"/>
-<wire x1="71.12" y1="33.02" x2="48.26" y2="33.02" width="0.1524" layer="91"/>
-<wire x1="48.26" y1="33.02" x2="27.94" y2="33.02" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="33.02" x2="12.7" y2="33.02" width="0.1524" layer="91"/>
-<wire x1="91.44" y1="33.02" x2="91.44" y2="27.94" width="0.1524" layer="91"/>
-<wire x1="91.44" y1="27.94" x2="91.44" y2="12.7" width="0.1524" layer="91"/>
-<wire x1="71.12" y1="33.02" x2="71.12" y2="12.7" width="0.1524" layer="91"/>
-<wire x1="48.26" y1="33.02" x2="48.26" y2="12.7" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="33.02" x2="27.94" y2="12.7" width="0.1524" layer="91"/>
-<wire x1="12.7" y1="27.94" x2="91.44" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="50.8" x2="17.78" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="45.72" x2="17.78" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="30.48" x2="33.02" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="30.48" x2="53.34" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="53.34" y1="30.48" x2="76.2" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="30.48" x2="96.52" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="50.8" x2="76.2" y2="50.8" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="50.8" x2="53.34" y2="50.8" width="0.1524" layer="91"/>
+<wire x1="53.34" y1="50.8" x2="33.02" y2="50.8" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="50.8" x2="17.78" y2="50.8" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="50.8" x2="96.52" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="45.72" x2="96.52" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="50.8" x2="76.2" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="53.34" y1="50.8" x2="53.34" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="50.8" x2="33.02" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="45.72" x2="96.52" y2="45.72" width="0.1524" layer="91"/>
 </segment>
 </net>
 </nets>

--- a/bloxa.sch
+++ b/bloxa.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.6.0">
+<eagle version="9.6.1">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -4248,7 +4248,7 @@ http://www.bccomponents.com/</description>
 <attributes>
 </attributes>
 <variantdefs>
-<variantdef name="Basic"/>
+<variantdef name="Basic" current="yes"/>
 <variantdef name="nocaps"/>
 </variantdefs>
 <classes>
@@ -4564,38 +4564,52 @@ as close as possible to the power transistors.</text>
 <wire x1="289.56" y1="63.5" x2="375.92" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="375.92" y1="63.5" x2="375.92" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="375.92" y1="134.62" x2="289.56" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
-<text x="25.4" y="48.26" size="1.27" layer="91" font="vector" ratio="15" align="center">DC power, W</text>
-<text x="43.18" y="48.26" size="1.27" layer="91" font="vector" ratio="15" align="center">Phase current, I</text>
-<text x="63.5" y="48.26" size="1.27" layer="91" font="vector" ratio="15" align="center">Total losses, W</text>
-<text x="86.36" y="48.26" size="1.27" layer="91" font="vector" ratio="15" align="center">Efficiency, %</text>
-<text x="25.4" y="43.18" size="1.27" layer="91" font="vector" ratio="15" align="center">100</text>
-<text x="25.4" y="40.64" size="1.27" layer="91" font="vector" ratio="15" align="center">150</text>
-<text x="25.4" y="38.1" size="1.27" layer="91" font="vector" ratio="15" align="center">200</text>
-<text x="25.4" y="35.56" size="1.27" layer="91" font="vector" ratio="15" align="center">250</text>
-<text x="25.4" y="33.02" size="1.27" layer="91" font="vector" ratio="15" align="center">300</text>
-<text x="55.88" y="27.94" size="1.27" layer="91" font="vector" ratio="15" align="center">The table is valid for 26.4 V supply voltage which is discharched 8S battery</text>
-<text x="43.18" y="43.18" size="1.27" layer="91" font="vector" ratio="15" align="center">4.8</text>
-<text x="63.5" y="43.18" size="1.27" layer="91" font="vector" ratio="15" align="center">1.7</text>
-<text x="86.36" y="43.18" size="1.27" layer="91" font="vector" ratio="15" align="center">98.3</text>
-<text x="43.18" y="40.64" size="1.27" layer="91" font="vector" ratio="15" align="center">7.2</text>
-<text x="63.5" y="40.64" size="1.27" layer="91" font="vector" ratio="15" align="center">3</text>
-<text x="86.36" y="40.64" size="1.27" layer="91" font="vector" ratio="15" align="center">98</text>
-<text x="43.18" y="38.1" size="1.27" layer="91" font="vector" ratio="15" align="center">9.6</text>
-<text x="63.5" y="38.1" size="1.27" layer="91" font="vector" ratio="15" align="center">4.5</text>
-<text x="86.36" y="38.1" size="1.27" layer="91" font="vector" ratio="15" align="center">97.7</text>
-<text x="43.18" y="35.56" size="1.27" layer="91" font="vector" ratio="15" align="center">12</text>
-<text x="63.5" y="35.56" size="1.27" layer="91" font="vector" ratio="15" align="center">6.3</text>
-<text x="86.36" y="35.56" size="1.27" layer="91" font="vector" ratio="15" align="center">97.5</text>
-<text x="43.18" y="33.02" size="1.27" layer="91" font="vector" ratio="15" align="center">14.4</text>
-<text x="63.5" y="33.02" size="1.27" layer="91" font="vector" ratio="15" align="center">8.4</text>
-<text x="86.36" y="33.02" size="1.27" layer="91" font="vector" ratio="15" align="center">97.2</text>
-<text x="58.42" y="53.34" size="1.27" layer="91" font="vector" ratio="15" align="center">Power losses for different power levels</text>
-<text x="63.5" y="111.76" size="1.778" layer="91" font="vector" ratio="15" align="center-left">R14 sets overcurrent protection trip level. 
+<text x="25.4" y="48.26" size="1.27" layer="97" font="vector" ratio="15" align="center">DC power, W</text>
+<text x="43.18" y="48.26" size="1.27" layer="97" font="vector" ratio="15" align="center">Phase current, I</text>
+<text x="63.5" y="48.26" size="1.27" layer="97" font="vector" ratio="15" align="center">Total losses, W</text>
+<text x="86.36" y="48.26" size="1.27" layer="97" font="vector" ratio="15" align="center">Efficiency, %</text>
+<text x="25.4" y="43.18" size="1.27" layer="97" font="vector" ratio="15" align="center">100</text>
+<text x="25.4" y="40.64" size="1.27" layer="97" font="vector" ratio="15" align="center">150</text>
+<text x="25.4" y="38.1" size="1.27" layer="97" font="vector" ratio="15" align="center">200</text>
+<text x="25.4" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">250</text>
+<text x="25.4" y="33.02" size="1.27" layer="97" font="vector" ratio="15" align="center">300</text>
+<text x="55.88" y="27.94" size="1.27" layer="97" font="vector" ratio="15" align="center">The table is valid for 26.4 V supply voltage which is discharched 8S battery</text>
+<text x="43.18" y="43.18" size="1.27" layer="97" font="vector" ratio="15" align="center">4.8</text>
+<text x="63.5" y="43.18" size="1.27" layer="97" font="vector" ratio="15" align="center">1.7</text>
+<text x="86.36" y="43.18" size="1.27" layer="97" font="vector" ratio="15" align="center">98.3</text>
+<text x="43.18" y="40.64" size="1.27" layer="97" font="vector" ratio="15" align="center">7.2</text>
+<text x="63.5" y="40.64" size="1.27" layer="97" font="vector" ratio="15" align="center">3</text>
+<text x="86.36" y="40.64" size="1.27" layer="97" font="vector" ratio="15" align="center">98</text>
+<text x="43.18" y="38.1" size="1.27" layer="97" font="vector" ratio="15" align="center">9.6</text>
+<text x="63.5" y="38.1" size="1.27" layer="97" font="vector" ratio="15" align="center">4.5</text>
+<text x="86.36" y="38.1" size="1.27" layer="97" font="vector" ratio="15" align="center">97.7</text>
+<text x="43.18" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">12</text>
+<text x="63.5" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">6.3</text>
+<text x="86.36" y="35.56" size="1.27" layer="97" font="vector" ratio="15" align="center">97.5</text>
+<text x="43.18" y="33.02" size="1.27" layer="97" font="vector" ratio="15" align="center">14.4</text>
+<text x="63.5" y="33.02" size="1.27" layer="97" font="vector" ratio="15" align="center">8.4</text>
+<text x="86.36" y="33.02" size="1.27" layer="97" font="vector" ratio="15" align="center">97.2</text>
+<text x="58.42" y="53.34" size="1.27" layer="97" font="vector" ratio="15" align="center">Power losses for different power levels</text>
+<text x="63.5" y="111.76" size="1.778" layer="97" font="vector" ratio="15" align="center-left">R14 sets overcurrent protection trip level. 
 680R sets ir arount 35A, which is 2.5 times 
 higher than maximum phase current for 300W DC power 
 when running on discharged 8S battery</text>
-<text x="88.9" y="246.38" size="1.778" layer="91" font="vector" ratio="15" align="center">For 3d model check this link
-https://a360.co/3asTElW</text>
+<wire x1="17.78" y1="50.8" x2="33.02" y2="50.8" width="0.1524" layer="97"/>
+<wire x1="33.02" y1="50.8" x2="53.34" y2="50.8" width="0.1524" layer="97"/>
+<wire x1="53.34" y1="50.8" x2="76.2" y2="50.8" width="0.1524" layer="97"/>
+<wire x1="76.2" y1="50.8" x2="96.52" y2="50.8" width="0.1524" layer="97"/>
+<wire x1="96.52" y1="50.8" x2="96.52" y2="45.72" width="0.1524" layer="97"/>
+<wire x1="96.52" y1="45.72" x2="96.52" y2="30.48" width="0.1524" layer="97"/>
+<wire x1="96.52" y1="30.48" x2="76.2" y2="30.48" width="0.1524" layer="97"/>
+<wire x1="76.2" y1="30.48" x2="53.34" y2="30.48" width="0.1524" layer="97"/>
+<wire x1="53.34" y1="30.48" x2="33.02" y2="30.48" width="0.1524" layer="97"/>
+<wire x1="33.02" y1="30.48" x2="17.78" y2="30.48" width="0.1524" layer="97"/>
+<wire x1="17.78" y1="30.48" x2="17.78" y2="45.72" width="0.1524" layer="97"/>
+<wire x1="17.78" y1="45.72" x2="17.78" y2="50.8" width="0.1524" layer="97"/>
+<wire x1="17.78" y1="45.72" x2="96.52" y2="45.72" width="0.1524" layer="97"/>
+<wire x1="76.2" y1="50.8" x2="76.2" y2="30.48" width="0.1524" layer="97"/>
+<wire x1="53.34" y1="50.8" x2="53.34" y2="30.48" width="0.1524" layer="97"/>
+<wire x1="33.02" y1="50.8" x2="33.02" y2="30.48" width="0.1524" layer="97"/>
 </plain>
 <instances>
 <instance part="+P2" gate="G$1" x="45.72" y="238.76" smashed="yes">
@@ -5614,6 +5628,12 @@ https://a360.co/3asTElW</text>
 <pinref part="R14" gate="G$1" pin="1"/>
 <pinref part="GND25" gate="1" pin="GND"/>
 </segment>
+<segment>
+<wire x1="342.9" y1="127" x2="350.52" y2="127" width="0.1524" layer="91"/>
+<pinref part="IC3" gate="G$1" pin="S"/>
+<pinref part="GND20" gate="1" pin="GND"/>
+<wire x1="350.52" y1="127" x2="350.52" y2="116.84" width="0.1524" layer="91"/>
+</segment>
 </net>
 <net name="GNDD" class="0">
 <segment>
@@ -5965,14 +5985,6 @@ https://a360.co/3asTElW</text>
 <wire x1="292.1" y1="210.82" x2="294.64" y2="210.82" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="N$2" class="0">
-<segment>
-<wire x1="342.9" y1="127" x2="350.52" y2="127" width="0.1524" layer="91"/>
-<pinref part="GND20" gate="1" pin="GND"/>
-<wire x1="350.52" y1="127" x2="350.52" y2="116.84" width="0.1524" layer="91"/>
-<pinref part="IC3" gate="G$1" pin="S"/>
-</segment>
-</net>
 <net name="N$4" class="0">
 <segment>
 <pinref part="LED3" gate="G$1" pin="G"/>
@@ -5986,32 +5998,12 @@ https://a360.co/3asTElW</text>
 <junction x="271.78" y="104.14"/>
 </segment>
 </net>
-<net name="N$1" class="0">
-<segment>
-<wire x1="17.78" y1="50.8" x2="17.78" y2="45.72" width="0.1524" layer="91"/>
-<wire x1="17.78" y1="45.72" x2="17.78" y2="30.48" width="0.1524" layer="91"/>
-<wire x1="17.78" y1="30.48" x2="33.02" y2="30.48" width="0.1524" layer="91"/>
-<wire x1="33.02" y1="30.48" x2="53.34" y2="30.48" width="0.1524" layer="91"/>
-<wire x1="53.34" y1="30.48" x2="76.2" y2="30.48" width="0.1524" layer="91"/>
-<wire x1="76.2" y1="30.48" x2="96.52" y2="30.48" width="0.1524" layer="91"/>
-<wire x1="96.52" y1="50.8" x2="76.2" y2="50.8" width="0.1524" layer="91"/>
-<wire x1="76.2" y1="50.8" x2="53.34" y2="50.8" width="0.1524" layer="91"/>
-<wire x1="53.34" y1="50.8" x2="33.02" y2="50.8" width="0.1524" layer="91"/>
-<wire x1="33.02" y1="50.8" x2="17.78" y2="50.8" width="0.1524" layer="91"/>
-<wire x1="96.52" y1="50.8" x2="96.52" y2="45.72" width="0.1524" layer="91"/>
-<wire x1="96.52" y1="45.72" x2="96.52" y2="30.48" width="0.1524" layer="91"/>
-<wire x1="76.2" y1="50.8" x2="76.2" y2="30.48" width="0.1524" layer="91"/>
-<wire x1="53.34" y1="50.8" x2="53.34" y2="30.48" width="0.1524" layer="91"/>
-<wire x1="33.02" y1="50.8" x2="33.02" y2="30.48" width="0.1524" layer="91"/>
-<wire x1="17.78" y1="45.72" x2="96.52" y2="45.72" width="0.1524" layer="91"/>
-</segment>
-</net>
 </nets>
 </sheet>
 <sheet>
 <description>changelog</description>
 <plain>
-<text x="7.62" y="101.6" size="1.778" layer="91" font="vector" align="center-left">-Current shunts replaced (5 mOhms replaced with 10 mOhms)-
+<text x="7.62" y="124.46" size="1.778" layer="97" font="vector" align="top-left">-Current shunts replaced (5 mOhms replaced with 10 mOhms)-
 -Overcurrent protection added. Itrip is ~35 A
 -RCPWM th connector replaced with smd solder pads
 -Some design notes added to the schematic</text>
@@ -6030,15 +6022,24 @@ https://a360.co/3asTElW</text>
 </sheet>
 </sheets>
 <errors>
-<approved hash="104,1,119.38,167.64,IC6,AVDD,N$37,,,"/>
-<approved hash="104,1,119.38,165.1,IC6,AGND,GND,,,"/>
-<approved hash="104,1,152.4,165.1,IC6,PVDD1,VBAT,,,"/>
-<approved hash="104,1,152.4,226.06,IC6,PVDD2,VBAT,,,"/>
-<approved hash="104,1,152.4,228.6,IC6,PVDD2,VBAT,,,"/>
-<approved hash="104,1,134.62,160.02,IC6,POWERPAD,GND,,,"/>
-<approved hash="206,1,152.4,220.98,N$4,,,,,"/>
-<approved hash="206,1,152.4,218.44,N$4,,,,,"/>
+<approved hash="106,1,45.72,137.16,CAN2_LED,,,,,"/>
+<approved hash="106,1,45.72,152.4,CAN2_RX,,,,,"/>
+<approved hash="106,1,45.72,154.94,CAN2_TX,,,,,"/>
+<approved hash="106,1,45.72,109.22,EN_GATE_OUT,,,,,"/>
+<approved hash="106,1,45.72,106.68,GAIN_OUT,,,,,"/>
+<approved hash="106,1,45.72,111.76,GPIO2,,,,,"/>
+<approved hash="106,1,45.72,96.52,POWER_ENABLE_IN,,,,,"/>
+<approved hash="106,1,45.72,91.44,USART_RX,,,,,"/>
+<approved hash="106,1,45.72,93.98,USART_TX,,,,,"/>
+<approved hash="106,1,45.72,132.08,USB+,,,,,"/>
+<approved hash="106,1,45.72,129.54,USB-,,,,,"/>
+<approved hash="106,1,45.72,127,USB_VBUS,,,,,"/>
+<approved hash="110,1,360.68,101.6,CAN1_VDD,GNDD,,,,"/>
+<approved hash="110,1,360.68,101.6,CAN1_VDD,GNDD,,,,"/>
+<approved hash="110,1,358.14,121.92,N$22,N$23,,,,"/>
+<approved hash="110,1,358.14,121.92,N$22,N$23,,,,"/>
 <approved hash="113,1,193.571,130.071,FRAME1,,,,,"/>
+<approved hash="113,2,91.971,66.571,FRAME2,,,,,"/>
 </errors>
 </schematic>
 </drawing>

--- a/bloxa.sch
+++ b/bloxa.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.3.0">
+<eagle version="9.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -99,6 +99,8 @@
 <layer number="116" name="Patch_BOT" color="9" fill="4" visible="yes" active="yes"/>
 <layer number="117" name="bMeasures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="118" name="Rect_Pads" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="119" name="KAP_TEKEN" color="7" fill="1" visible="no" active="no"/>
+<layer number="120" name="KAP_MAAT1" color="7" fill="1" visible="no" active="no"/>
 <layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="122" name="_bsilk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
@@ -107,9 +109,11 @@
 <layer number="126" name="_bnames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="127" name="_tvalues" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="128" name="_bvalues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="129" name="top_silk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="130" name="bLogo" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="133" name="bottom_silk" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="145" name="DrillLegend_01-16" color="2" fill="9" visible="yes" active="yes"/>
 <layer number="146" name="DrillLegend_01-20" color="3" fill="9" visible="yes" active="yes"/>
@@ -869,7 +873,7 @@ DIN A3, landscape with location and doc. field</description>
 <smd name="P$1" x="0" y="0" dx="1.5" dy="1.5" layer="1" roundness="100"/>
 <circle x="0" y="0" radius="0.9" width="0.1" layer="21"/>
 </package>
-<package name="HOLE_1.5" urn="urn:adsk.eagle:footprint:3332367/2" locally_modified="yes" library_version="8" library_locally_modified="yes">
+<package name="HOLE_1.5" urn="urn:adsk.eagle:footprint:3332367/3" library_version="21" library_locally_modified="yes">
 <pad name="P$1" x="0" y="0" drill="1.5" diameter="2.35"/>
 <text x="0" y="2.54" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
@@ -979,16 +983,163 @@ DIN A3, landscape with location and doc. field</description>
 <pad name="P$1" x="0" y="0" drill="3"/>
 <text x="0" y="3.06" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
-<package name="HOLE_0.6" urn="urn:adsk.eagle:footprint:6513717/1" locally_modified="yes" library_version="8" library_locally_modified="yes">
+<package name="HOLE_0.6" urn="urn:adsk.eagle:footprint:6513717/2" library_version="21" library_locally_modified="yes">
 <pad name="P$1" x="0" y="0" drill="0.6" shape="square"/>
 </package>
-<package name="HOLE_1" urn="urn:adsk.eagle:footprint:3188698/2" locally_modified="yes" library_version="8" library_locally_modified="yes">
+<package name="SMD_1X1,5" urn="urn:adsk.eagle:footprint:7879125/1" library_version="21" library_locally_modified="yes">
+<smd name="P$1" x="0" y="0" dx="1" dy="1.5" layer="1" roundness="25" rot="R180"/>
+</package>
+<package name="HOLE_1_SQUARE" urn="urn:adsk.eagle:footprint:3188698/4" library_version="21" library_locally_modified="yes">
 <pad name="P$1" x="0" y="0" drill="0.8" diameter="1.4" shape="square"/>
 <text x="1" y="0" size="1.27" layer="25" font="vector" ratio="15" align="center-left">&gt;NAME</text>
 <circle x="0" y="0" radius="0.3" width="0.4" layer="21"/>
 </package>
-<package name="SMD_1X1,5" library_version="8" library_locally_modified="yes">
-<smd name="P$1" x="0" y="0" dx="1" dy="1.5" layer="1" roundness="25" rot="R180"/>
+<package name="2MM_BULLET" urn="urn:adsk.eagle:footprint:7879124/1" library_version="21" library_locally_modified="yes">
+<pad name="P$1" x="0" y="0" drill="2.1" shape="square"/>
+<wire x1="-1.8" y1="1.6" x2="-1.8" y2="1.8" width="0.127" layer="21"/>
+<wire x1="-1.8" y1="1.8" x2="1.8" y2="1.8" width="0.127" layer="21"/>
+<wire x1="1.8" y1="1.8" x2="1.8" y2="-1.8" width="0.127" layer="21"/>
+<wire x1="1.8" y1="-1.8" x2="-1.5" y2="-1.8" width="0.127" layer="21"/>
+<wire x1="-1.5" y1="-1.8" x2="-1.8" y2="-1.8" width="0.127" layer="21"/>
+<wire x1="-1.8" y1="-1.8" x2="-1.8" y2="1.6" width="0.127" layer="21"/>
+</package>
+<package name="HOLE_1.7" urn="urn:adsk.eagle:footprint:8242903/1" library_version="21" library_locally_modified="yes">
+<pad name="P$1" x="0" y="0" drill="1.7" diameter="2.35"/>
+<text x="0" y="2" size="1" layer="21" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="HOLE_1_OCTO" urn="urn:adsk.eagle:footprint:8242902/1" library_version="21" library_locally_modified="yes">
+<pad name="P$1" x="0" y="0" drill="0.8" diameter="1.4" shape="octagon"/>
+<text x="1" y="0" size="1.27" layer="25" font="vector" ratio="15" align="center-left">&gt;NAME</text>
+<circle x="0" y="0" radius="0.3" width="0.4" layer="21"/>
+</package>
+<package name="HOLE_1_ROUND" urn="urn:adsk.eagle:footprint:11388395/1" library_version="21" library_locally_modified="yes">
+<pad name="P$1" x="0" y="0" drill="0.8" diameter="1.4"/>
+<text x="1" y="0" size="1.27" layer="25" font="vector" ratio="15" align="center-left">&gt;NAME</text>
+<circle x="0" y="0" radius="0.3" width="0.4" layer="21"/>
+</package>
+<package name="HOLE_0.5" urn="urn:adsk.eagle:footprint:11388397/1" library_version="21" library_locally_modified="yes">
+<pad name="P$1" x="0" y="0" drill="0.5" shape="square"/>
+</package>
+<package name="HOLE_0.8" urn="urn:adsk.eagle:footprint:11388398/1" library_version="21" library_locally_modified="yes">
+<pad name="P$1" x="0" y="0" drill="0.8"/>
+</package>
+<package name="HOLE_4" urn="urn:adsk.eagle:footprint:11388399/1" library_version="21" library_locally_modified="yes">
+<pad name="P$1" x="0" y="0" drill="4"/>
+<text x="0" y="3.06" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="7461095" urn="urn:adsk.eagle:footprint:11388396/1" library_version="21" library_locally_modified="yes">
+<wire x1="-4.5" y1="-4.5" x2="-4.5" y2="4.5" width="0.2" layer="51"/>
+<wire x1="-4.5" y1="4.5" x2="4.5" y2="4.5" width="0.2" layer="51"/>
+<wire x1="4.5" y1="4.5" x2="4.5" y2="-4.5" width="0.2" layer="51"/>
+<wire x1="4.5" y1="-4.5" x2="-4.5" y2="-4.5" width="0.2" layer="51"/>
+<pad name="P$1" x="-1.27" y="1.27" drill="1.6" diameter="2.1"/>
+<pad name="P$2" x="-1.27" y="-1.27" drill="1.6" diameter="2.1"/>
+<pad name="P$3" x="1.27" y="-1.27" drill="1.6" diameter="2.1"/>
+<pad name="P$4" x="1.27" y="1.27" drill="1.6" diameter="2.1"/>
+<pad name="P$5" x="1.27" y="3.81" drill="1.6" diameter="2.1"/>
+<pad name="P$6" x="-1.27" y="3.81" drill="1.6" diameter="2.1"/>
+<pad name="P$7" x="-3.81" y="3.81" drill="1.6" diameter="2.1"/>
+<pad name="P$8" x="-3.81" y="1.27" drill="1.6" diameter="2.1"/>
+<pad name="P$9" x="-3.81" y="-1.27" drill="1.6" diameter="2.1"/>
+<pad name="P$10" x="-3.81" y="-3.81" drill="1.6" diameter="2.1"/>
+<pad name="P$11" x="-1.27" y="-3.81" drill="1.6" diameter="2.1"/>
+<pad name="P$12" x="1.27" y="-3.81" drill="1.6" diameter="2.1"/>
+<pad name="P$13" x="3.81" y="-3.81" drill="1.6" diameter="2.1"/>
+<pad name="P$14" x="3.81" y="-1.27" drill="1.6" diameter="2.1"/>
+<pad name="P$15" x="3.81" y="1.27" drill="1.6" diameter="2.1"/>
+<pad name="P$16" x="3.81" y="3.81" drill="1.6" diameter="2.1"/>
+<text x="0" y="6" size="2" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="74650194R" urn="urn:adsk.eagle:footprint:11388440/1" library_version="21" library_locally_modified="yes">
+<pad name="P$1" x="0" y="0" drill="1.85"/>
+<pad name="P$2" x="-4.435" y="0" drill="1.85"/>
+<pad name="P$3" x="4.435" y="0" drill="1.85"/>
+<pad name="P$4" x="4.435" y="-4.435" drill="1.85"/>
+<pad name="P$5" x="0" y="-4.435" drill="1.85"/>
+<pad name="P$6" x="-4.435" y="-4.435" drill="1.85"/>
+<pad name="P$7" x="-4.435" y="4.435" drill="1.85"/>
+<pad name="P$8" x="0" y="4.435" drill="1.85"/>
+<pad name="P$9" x="4.435" y="4.435" drill="1.85"/>
+<wire x1="-5" y1="5" x2="-5" y2="-5" width="0.2" layer="51"/>
+<wire x1="-5" y1="-5" x2="5" y2="-5" width="0.2" layer="51"/>
+<wire x1="5" y1="-5" x2="5" y2="5" width="0.2" layer="51"/>
+<wire x1="5" y1="5" x2="-5" y2="5" width="0.2" layer="51"/>
+<text x="0" y="7" size="2" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="7461148" urn="urn:adsk.eagle:footprint:11388671/2" library_version="21" library_locally_modified="yes">
+<pad name="P$2" x="-2.54" y="0" drill="1.6" diameter="2.1"/>
+<pad name="P$3" x="-2.54" y="2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$4" x="0" y="2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$5" x="2.54" y="2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$6" x="2.54" y="0" drill="1.6" diameter="2.1"/>
+<pad name="P$7" x="2.54" y="-2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$8" x="0" y="-2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$9" x="-2.54" y="-2.54" drill="1.6" diameter="2.1"/>
+<wire x1="-3.5" y1="-3.5" x2="-3.5" y2="3.5" width="0.1" layer="51"/>
+<wire x1="-3.5" y1="3.5" x2="3.5" y2="3.5" width="0.1" layer="51"/>
+<wire x1="3.5" y1="3.5" x2="3.5" y2="-3.5" width="0.1" layer="51"/>
+<wire x1="3.5" y1="-3.5" x2="-3.5" y2="-3.5" width="0.1" layer="51"/>
+<text x="0" y="4.7" size="2" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="7461094" urn="urn:adsk.eagle:footprint:11388721/1" library_version="21" library_locally_modified="yes">
+<pad name="P$2" x="-2.54" y="0" drill="1.6" diameter="2.1"/>
+<pad name="P$3" x="-2.54" y="2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$4" x="0" y="2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$5" x="2.54" y="2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$6" x="2.54" y="0" drill="1.6" diameter="2.1"/>
+<pad name="P$7" x="2.54" y="-2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$8" x="0" y="-2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$9" x="-2.54" y="-2.54" drill="1.6" diameter="2.1"/>
+<pad name="P$1" x="0" y="0" drill="1.6" diameter="2.1"/>
+<wire x1="-3.5" y1="-3.5" x2="-3.5" y2="3.5" width="0.1" layer="51"/>
+<wire x1="-3.5" y1="3.5" x2="3.5" y2="3.5" width="0.1" layer="51"/>
+<wire x1="3.5" y1="3.5" x2="3.5" y2="-3.5" width="0.1" layer="51"/>
+<wire x1="3.5" y1="-3.5" x2="-3.5" y2="-3.5" width="0.1" layer="51"/>
+<text x="0" y="4.7" size="2" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="2X1.5" urn="urn:adsk.eagle:footprint:11682467/1" library_version="21" library_locally_modified="yes">
+<smd name="P$1" x="0" y="0" dx="2" dy="1.5" layer="1" roundness="50"/>
+<wire x1="0.75" y1="-0.9" x2="-0.75" y2="-0.9" width="0.127" layer="51"/>
+<wire x1="-0.75" y1="-0.9" x2="-1.15" y2="-0.5" width="0.127" layer="51" curve="-90"/>
+<wire x1="-1.15" y1="-0.5" x2="-1.15" y2="0.5" width="0.127" layer="51"/>
+<wire x1="-1.15" y1="0.5" x2="-0.75" y2="0.9" width="0.127" layer="51" curve="-90"/>
+<wire x1="-0.75" y1="0.9" x2="0.75" y2="0.9" width="0.127" layer="51"/>
+<wire x1="0.75" y1="0.9" x2="1.15" y2="0.5" width="0.127" layer="51" curve="-90"/>
+<wire x1="1.15" y1="0.5" x2="1.15" y2="-0.5" width="0.127" layer="51"/>
+<wire x1="1.15" y1="-0.5" x2="0.75" y2="-0.9" width="0.127" layer="51" curve="-90"/>
+</package>
+<package name="HOLE_1.77" urn="urn:adsk.eagle:footprint:15477725/1" library_version="21" library_locally_modified="yes">
+<pad name="P$1" x="0" y="0" drill="1.77" diameter="2.35"/>
+<text x="0" y="2" size="1" layer="21" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="1.2X1.2" urn="urn:adsk.eagle:footprint:15477727/1" locally_modified="yes" library_version="21" library_locally_modified="yes">
+<smd name="P$1" x="0" y="0" dx="1.2" dy="1.2" layer="1" roundness="100"/>
+<circle x="0" y="0" radius="0.548290625" width="0.1" layer="51"/>
+</package>
+<package name="1.5X1.5" urn="urn:adsk.eagle:footprint:15477726/1" library_version="21" library_locally_modified="yes">
+<smd name="P$1" x="0" y="0" dx="1.5" dy="1.5" layer="1" roundness="100"/>
+</package>
+<package name="1X1" urn="urn:adsk.eagle:footprint:15477728/1" library_version="21" library_locally_modified="yes">
+<smd name="P$1" x="0" y="0" dx="1" dy="1" layer="1" roundness="100"/>
+</package>
+<package name="8199" urn="urn:adsk.eagle:footprint:15636605/1" library_version="21" library_locally_modified="yes">
+<description>https://www.keyelco.com/product.cfm/30-Amp-Screw-Terminals/8199/product_id/1550</description>
+<pad name="P$1" x="0" y="3.5" drill="2"/>
+<pad name="P$2" x="0" y="-3.5" drill="2"/>
+<pad name="P$3" x="-5" y="3.5" drill="2"/>
+<pad name="P$4" x="-5" y="-3.5" drill="2"/>
+<pad name="P$5" x="5" y="3.5" drill="2"/>
+<pad name="P$6" x="5" y="-3.5" drill="2"/>
+<wire x1="-6.7" y1="5.2" x2="6.7" y2="5.2" width="0.1" layer="21"/>
+<wire x1="6.7" y1="5.2" x2="6.7" y2="-5.2" width="0.1" layer="21"/>
+<wire x1="6.7" y1="-5.2" x2="-6.7" y2="-5.2" width="0.1" layer="21"/>
+<wire x1="-6.7" y1="-5.2" x2="-6.7" y2="5.2" width="0.1" layer="21"/>
+<text x="0" y="0" size="2" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="R75-3X" urn="urn:adsk.eagle:footprint:6366932/1" library_version="21" library_locally_modified="yes">
+<pad name="1" x="0" y="0" drill="1.1"/>
+<text x="0" y="-1.6" size="0.7" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<circle x="0" y="0" radius="1" width="0.1" layer="25"/>
 </package>
 </packages>
 <packages3d>
@@ -1017,7 +1168,7 @@ DIN A3, landscape with location and doc. field</description>
 <packageinstance name="2х2"/>
 </packageinstances>
 </package3d>
-<package3d name="HOLE_1.5" urn="urn:adsk.eagle:package:3332368/2" locally_modified="yes" type="box" library_version="8" library_locally_modified="yes">
+<package3d name="HOLE_1.5" urn="urn:adsk.eagle:package:3332368/3" type="box" library_version="21" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="HOLE_1.5"/>
 </packageinstances>
@@ -1084,14 +1235,110 @@ DIN A3, landscape with location and doc. field</description>
 <packageinstance name="HOLE_3"/>
 </packageinstances>
 </package3d>
-<package3d name="HOLE_0.6" urn="urn:adsk.eagle:package:6513718/1" locally_modified="yes" type="box" library_version="8" library_locally_modified="yes">
+<package3d name="HOLE_0.6" urn="urn:adsk.eagle:package:6513718/2" type="box" library_version="21" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="HOLE_0.6"/>
 </packageinstances>
 </package3d>
-<package3d name="HOLE_1" urn="urn:adsk.eagle:package:3188705/3" locally_modified="yes" type="box" library_version="8" library_locally_modified="yes">
+<package3d name="SMD_1X1,5" urn="urn:adsk.eagle:package:7879127/1" type="box" library_version="21" library_locally_modified="yes">
 <packageinstances>
-<packageinstance name="HOLE_1"/>
+<packageinstance name="SMD_1X1,5"/>
+</packageinstances>
+</package3d>
+<package3d name="HOLE_1" urn="urn:adsk.eagle:package:3188705/5" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="HOLE_1_SQUARE"/>
+</packageinstances>
+</package3d>
+<package3d name="2MM_BULLET" urn="urn:adsk.eagle:package:7879126/2" type="model" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="2MM_BULLET"/>
+</packageinstances>
+</package3d>
+<package3d name="HOLE_1.7" urn="urn:adsk.eagle:package:8242905/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="HOLE_1.7"/>
+</packageinstances>
+</package3d>
+<package3d name="HOLE_1_OCTO" urn="urn:adsk.eagle:package:8242904/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="HOLE_1_OCTO"/>
+</packageinstances>
+</package3d>
+<package3d name="HOLE_1_ROUND" urn="urn:adsk.eagle:package:11388402/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="HOLE_1_ROUND"/>
+</packageinstances>
+</package3d>
+<package3d name="HOLE_0.5" urn="urn:adsk.eagle:package:11388401/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="HOLE_0.5"/>
+</packageinstances>
+</package3d>
+<package3d name="HOLE_0.8" urn="urn:adsk.eagle:package:11388400/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="HOLE_0.8"/>
+</packageinstances>
+</package3d>
+<package3d name="HOLE_4" urn="urn:adsk.eagle:package:11388404/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="HOLE_4"/>
+</packageinstances>
+</package3d>
+<package3d name="7461095" urn="urn:adsk.eagle:package:11388403/2" type="model" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="7461095"/>
+</packageinstances>
+</package3d>
+<package3d name="74650194R" urn="urn:adsk.eagle:package:11388441/2" type="model" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="74650194R"/>
+</packageinstances>
+</package3d>
+<package3d name="7461148" urn="urn:adsk.eagle:package:11388672/3" type="model" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="7461148"/>
+</packageinstances>
+</package3d>
+<package3d name="7461094" urn="urn:adsk.eagle:package:11388722/2" type="model" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="7461094"/>
+</packageinstances>
+</package3d>
+<package3d name="2X1.5" urn="urn:adsk.eagle:package:11682468/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="2X1.5"/>
+</packageinstances>
+</package3d>
+<package3d name="HOLE_1.77" urn="urn:adsk.eagle:package:15477729/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="HOLE_1.77"/>
+</packageinstances>
+</package3d>
+<package3d name="1.2X1.2" urn="urn:adsk.eagle:package:15477731/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="1.2X1.2"/>
+</packageinstances>
+</package3d>
+<package3d name="1.5X1.5" urn="urn:adsk.eagle:package:15477730/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="1.5X1.5"/>
+</packageinstances>
+</package3d>
+<package3d name="1X1" urn="urn:adsk.eagle:package:15477732/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="1X1"/>
+</packageinstances>
+</package3d>
+<package3d name="8199" urn="urn:adsk.eagle:package:15636606/2" type="model" library_version="21" library_locally_modified="yes">
+<description>https://www.keyelco.com/product.cfm/30-Amp-Screw-Terminals/8199/product_id/1550</description>
+<packageinstances>
+<packageinstance name="8199"/>
+</packageinstances>
+</package3d>
+<package3d name="R75-3X" urn="urn:adsk.eagle:package:6366935/1" type="box" library_version="21" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R75-3X"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -1104,7 +1351,7 @@ DIN A3, landscape with location and doc. field</description>
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="PAD" urn="urn:adsk.eagle:component:3188710/8" locally_modified="yes" prefix="PAD" library_version="8" library_locally_modified="yes">
+<deviceset name="PAD" urn="urn:adsk.eagle:component:3188710/19" locally_modified="yes" prefix="PAD" library_version="21" library_locally_modified="yes">
 <gates>
 <gate name="G$1" symbol="PAD" x="-20.32" y="7.62"/>
 </gates>
@@ -1161,12 +1408,12 @@ DIN A3, landscape with location and doc. field</description>
 </technology>
 </technologies>
 </device>
-<device name="-HOLE_1" package="HOLE_1">
+<device name="-HOLE_1" package="HOLE_1_SQUARE">
 <connects>
 <connect gate="G$1" pin="P$1" pad="P$1"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:3188705/3"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:3188705/5"/>
 </package3dinstances>
 <technologies>
 <technology name="">
@@ -1192,7 +1439,7 @@ DIN A3, landscape with location and doc. field</description>
 <connect gate="G$1" pin="P$1" pad="P$1"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:3332368/2"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:3332368/3"/>
 </package3dinstances>
 <technologies>
 <technology name="">
@@ -1361,7 +1608,7 @@ DIN A3, landscape with location and doc. field</description>
 <connect gate="G$1" pin="P$1" pad="P$1"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:6513718/1"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6513718/2"/>
 </package3dinstances>
 <technologies>
 <technology name=""/>
@@ -1371,6 +1618,216 @@ DIN A3, landscape with location and doc. field</description>
 <connects>
 <connect gate="G$1" pin="P$1" pad="P$1"/>
 </connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:7879127/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-2MM_BULLET" package="2MM_BULLET">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:7879126/2"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-HOLE-1.7" package="HOLE_1.7">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:8242905/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-HOLE_1_OCTO" package="HOLE_1_OCTO">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:8242904/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-HOLE-1-ROUND" package="HOLE_1_ROUND">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11388402/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-HOLE-0.5" package="HOLE_0.5">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11388401/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-HOLE-0.8" package="HOLE_0.8">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11388400/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-HOLE_4" package="HOLE_4">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11388404/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-7461095" package="7461095">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1 P$2 P$3 P$4 P$5 P$6 P$7 P$8 P$9 P$10 P$11 P$12 P$13 P$14 P$15 P$16"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11388403/2"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-74650194R" package="74650194R">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1 P$2 P$3 P$4 P$5 P$6 P$7 P$8 P$9"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11388441/2"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-7461148" package="7461148">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$2 P$3 P$4 P$5 P$6 P$7 P$8 P$9"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11388672/3"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-77461094" package="7461094">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1 P$2 P$3 P$4 P$5 P$6 P$7 P$8 P$9"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11388722/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="CURRENT_RATING" value="130A" constant="no"/>
+<attribute name="DIGIKEY#" value="732-3212-ND" constant="no"/>
+<attribute name="MANF" value="Wurth Electronics Inc" constant="no"/>
+<attribute name="MANF#" value="7461094" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-2X1.5" package="2X1.5">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11682468/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-HOLE-1.77" package="HOLE_1.77">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:15477729/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-S-1.2" package="1.2X1.2">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:15477731/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-S-1.5" package="1.5X1.5">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:15477730/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-S-1" package="1X1">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:15477732/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-8199" package="8199">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1 P$2 P$3 P$4 P$5 P$6"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:15636606/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="DIGIKEY#" value="36-8199-ND" constant="no"/>
+<attribute name="MANF" value="Keystone Electronics" constant="no"/>
+<attribute name="MANF#" value="8199" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-R75-3X" package="R75-3X">
+<connects>
+<connect gate="G$1" pin="P$1" pad="1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6366935/1"/>
+</package3dinstances>
 <technologies>
 <technology name=""/>
 </technologies>
@@ -1846,6 +2303,33 @@ DIN A3, landscape with location and doc. field</description>
 <rectangle x1="-3.2" y1="-1.5" x2="-2.5" y2="1.5" layer="51"/>
 <rectangle x1="2.5" y1="-1.5" x2="3.2" y2="1.5" layer="51"/>
 </package>
+<package name="R2010-KELVIN" urn="urn:adsk.eagle:footprint:8637301/1" library_version="16">
+<wire x1="3.45" y1="-1.9" x2="3.45" y2="1.9" width="0.15" layer="21"/>
+<wire x1="3.45" y1="1.9" x2="-3.45" y2="1.9" width="0.15" layer="21"/>
+<wire x1="-3.45" y1="1.9" x2="-3.45" y2="-1.9" width="0.15" layer="21"/>
+<wire x1="-3.45" y1="-1.9" x2="3.45" y2="-1.9" width="0.15" layer="21"/>
+<text x="0" y="0" size="1.3" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="0" y="-2.7" size="1.3" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
+<smd name="S1" x="-2.5" y="0" dx="1.5" dy="0.6" layer="1"/>
+<smd name="1" x="-2.5" y="1.2" dx="1.5" dy="1" layer="1"/>
+<smd name="11" x="-2.5" y="-1.2" dx="1.5" dy="1" layer="1"/>
+<smd name="S2" x="2.5" y="0" dx="1.5" dy="0.6" layer="1"/>
+<smd name="2" x="2.5" y="1.2" dx="1.5" dy="1" layer="1"/>
+<smd name="22" x="2.5" y="-1.2" dx="1.5" dy="1" layer="1"/>
+</package>
+<package name="R3920-KELVIN" urn="urn:adsk.eagle:footprint:10874635/1" library_version="16">
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<smd name="1" x="-4.15" y="1.85" dx="2.7" dy="2.5" layer="1"/>
+<smd name="2" x="4.15" y="1.85" dx="2.7" dy="2.5" layer="1"/>
+<smd name="11" x="-4.15" y="-1.85" dx="2.7" dy="2.5" layer="1"/>
+<smd name="S1" x="-4.15" y="0" dx="2.7" dy="0.6" layer="1"/>
+<smd name="22" x="4.15" y="-1.85" dx="2.7" dy="2.5" layer="1"/>
+<smd name="S2" x="4.15" y="0" dx="2.7" dy="0.6" layer="1"/>
+<wire x1="-5.7" y1="3.3" x2="-5.7" y2="-3.3" width="0.1" layer="21"/>
+<wire x1="-5.7" y1="-3.3" x2="5.7" y2="-3.3" width="0.1" layer="21"/>
+<wire x1="5.7" y1="-3.3" x2="5.7" y2="3.3" width="0.1" layer="21"/>
+<wire x1="5.7" y1="3.3" x2="-5.7" y2="3.3" width="0.1" layer="21"/>
+</package>
 </packages>
 <packages3d>
 <package3d name="R2512-KELVIN" urn="urn:adsk.eagle:package:3560627/3" type="model" library_version="5" library_locally_modified="yes">
@@ -1861,6 +2345,16 @@ DIN A3, landscape with location and doc. field</description>
 <package3d name="R2512-WIRE-KELVIN" urn="urn:adsk.eagle:package:6401683/2" type="model" library_version="8" library_locally_modified="yes">
 <packageinstances>
 <packageinstance name="R2512-WIRE-KELVIN"/>
+</packageinstances>
+</package3d>
+<package3d name="R2010-KELVIN" urn="urn:adsk.eagle:package:8637302/2" type="model" library_version="16">
+<packageinstances>
+<packageinstance name="R2010-KELVIN"/>
+</packageinstances>
+</package3d>
+<package3d name="R3920-KELVIN" urn="urn:adsk.eagle:package:10874636/2" type="model" library_version="16">
+<packageinstances>
+<packageinstance name="R3920-KELVIN"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -1887,7 +2381,7 @@ DIN A3, landscape with location and doc. field</description>
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="CURRENT_SHUNT_KELVIN" urn="urn:adsk.eagle:component:3560628/7" locally_modified="yes" prefix="R" library_version="9" library_locally_modified="yes">
+<deviceset name="CURRENT_SHUNT_KELVIN" urn="urn:adsk.eagle:component:3560628/12" prefix="R" library_version="16">
 <gates>
 <gate name="G$1" symbol="SHUNT_4_TERMINAL" x="2.54" y="2.54"/>
 </gates>
@@ -1938,6 +2432,15 @@ DIN A3, landscape with location and doc. field</description>
 <attribute name="TC" value="±50ppm/°C" constant="no"/>
 <attribute name="TOLERANCE" value="±1%" constant="no"/>
 <attribute name="VALUE" value="5 mOhms" constant="no"/>
+</technology>
+<technology name="-0.010R">
+<attribute name="DIGIKEY#" value="CSNL2512FT10L0CT-ND" constant="no"/>
+<attribute name="MANF" value="Stackpole Electronics Inc" constant="no"/>
+<attribute name="MANF#" value="CSNL2512FT10L0" constant="no"/>
+<attribute name="POWER" value="2W" constant="no"/>
+<attribute name="TC" value="±50ppm/°C" constant="no"/>
+<attribute name="TOLERANCE" value="±1%" constant="no"/>
+<attribute name="VALUE" value="10 mOhms" constant="no"/>
 </technology>
 </technologies>
 </device>
@@ -1991,6 +2494,60 @@ DIN A3, landscape with location and doc. field</description>
 <attribute name="TC" value="±50ppm/°C" constant="no"/>
 <attribute name="TOLERANCE" value="±1%" constant="no"/>
 <attribute name="VALUE" value="500 µOhms" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-2010-KELVIN" package="R2010-KELVIN">
+<connects>
+<connect gate="G$1" pin="1" pad="1 11"/>
+<connect gate="G$1" pin="2" pad="2 22"/>
+<connect gate="G$1" pin="S1" pad="S1"/>
+<connect gate="G$1" pin="S2" pad="S2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:8637302/2"/>
+</package3dinstances>
+<technologies>
+<technology name="-0.001R">
+<attribute name="DIGIKEY#" value="CSNL2010FT1L00TR-ND" constant="no"/>
+<attribute name="MANF" value="Stackpole Electronics Inc." constant="no"/>
+<attribute name="MANF#" value="CSNL2010FT1L00" constant="no"/>
+<attribute name="POWER" value="1.5W" constant="no"/>
+<attribute name="TC" value="±50ppm/°C" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+<attribute name="VALUE" value="0.001R" constant="no"/>
+</technology>
+<technology name="-0.005R">
+<attribute name="DIGIKEY#" value="CSNL2010FT5L00CT-ND" constant="no"/>
+<attribute name="MANF" value="Stackpole Electronics Inc." constant="no"/>
+<attribute name="MANF#" value="CSNL2010FT5L00" constant="no"/>
+<attribute name="POWER" value="1.5W" constant="no"/>
+<attribute name="TC" value="±50ppm/°C" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+<attribute name="VALUE" value="0.005R" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-3920-KELVIN" package="R3920-KELVIN">
+<connects>
+<connect gate="G$1" pin="1" pad="1 11"/>
+<connect gate="G$1" pin="2" pad="2 22"/>
+<connect gate="G$1" pin="S1" pad="S1"/>
+<connect gate="G$1" pin="S2" pad="S2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:10874636/2"/>
+</package3dinstances>
+<technologies>
+<technology name="-0.001R">
+<attribute name="DIGIKEY#" value="CSS2H-3920R-1L00FTR-ND" constant="no"/>
+<attribute name="MANF" value="Bourns Inc" constant="no"/>
+<attribute name="MANF#" value="CSS2H-3920R-1L00F" constant="no"/>
+<attribute name="PACKAGE" value="3920" constant="no"/>
+<attribute name="POWER" value="8W" constant="no"/>
+<attribute name="TC" value="±50ppm/°C" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+<attribute name="VALUE" value="0.001R" constant="no"/>
 </technology>
 </technologies>
 </device>
@@ -2971,6 +3528,57 @@ http://www.bccomponents.com/</description>
 <text x="0" y="-1.5" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 <text x="-1.2" y="1.4" size="1.27" layer="21" font="vector" ratio="15" align="center">+</text>
 </package>
+<package name="R0402" urn="urn:adsk.eagle:footprint:2539434/1" library_version="46" library_locally_modified="yes">
+<smd name="1" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="2" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="12" align="center">&gt;NAME</text>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
+</package>
+<package name="R0805" urn="urn:adsk.eagle:footprint:2539435/1" library_version="46" library_locally_modified="yes">
+<smd name="1" x="-1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<smd name="2" x="1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<wire x1="-1.65" y1="0.85" x2="1.65" y2="0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="0.85" x2="1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="-0.85" x2="-1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="-1.65" y1="-0.85" x2="-1.65" y2="0.85" width="0.127" layer="21"/>
+<text x="0" y="0" size="0.635" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="R0603" urn="urn:adsk.eagle:footprint:2539436/1" library_version="46" library_locally_modified="yes">
+<smd name="1" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<smd name="2" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<wire x1="-1.125" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
+</package>
+<package name="R1206" urn="urn:adsk.eagle:footprint:2539441/1" library_version="46" library_locally_modified="yes">
+<smd name="P$1" x="-1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
+<smd name="P$2" x="1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
+<text x="0" y="0" size="0.762" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-2.2" y1="1" x2="2.2" y2="1" width="0.15" layer="21"/>
+<wire x1="2.2" y1="1" x2="2.2" y2="-1" width="0.15" layer="21"/>
+<wire x1="2.2" y1="-1" x2="-2.2" y2="-1" width="0.15" layer="21"/>
+<wire x1="-2.2" y1="-1" x2="-2.2" y2="1" width="0.15" layer="21"/>
+</package>
+<package name="R2512" urn="urn:adsk.eagle:footprint:1040086/1" library_version="46" library_locally_modified="yes">
+<description>http://www.resistor.com/assets/pdf/2512std.pdf</description>
+<smd name="1" x="-3.25" y="0" dx="3.2" dy="1.25" layer="1" rot="R90"/>
+<smd name="2" x="3.25" y="0" dx="3.2" dy="1.25" layer="1" rot="R90"/>
+<wire x1="-4.05" y1="1.75" x2="4.05" y2="1.75" width="0.1" layer="21"/>
+<wire x1="4.05" y1="1.75" x2="4.05" y2="-1.75" width="0.1" layer="21"/>
+<wire x1="4.05" y1="-1.75" x2="-4.05" y2="-1.75" width="0.1" layer="21"/>
+<wire x1="-4.05" y1="-1.75" x2="-4.05" y2="1.75" width="0.1" layer="21"/>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
 </packages>
 <packages3d>
 <package3d name="153CLV-0810" urn="urn:adsk.eagle:package:4491937/3" type="model" library_version="25" library_locally_modified="yes">
@@ -3044,6 +3652,32 @@ http://www.bccomponents.com/</description>
 <packageinstance name="RADIAL_6.3X12.5"/>
 </packageinstances>
 </package3d>
+<package3d name="R0402" urn="urn:adsk.eagle:package:2539456/2" type="model" library_version="46" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R0402"/>
+</packageinstances>
+</package3d>
+<package3d name="R0805" urn="urn:adsk.eagle:package:2539455/2" type="model" library_version="46" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R0805"/>
+</packageinstances>
+</package3d>
+<package3d name="R0603" urn="urn:adsk.eagle:package:2539454/2" type="model" library_version="46" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R0603"/>
+</packageinstances>
+</package3d>
+<package3d name="R1206" urn="urn:adsk.eagle:package:2539464/2" type="model" library_version="46" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R1206"/>
+</packageinstances>
+</package3d>
+<package3d name="R2512" urn="urn:adsk.eagle:package:4855216/2" type="model" library_version="46" library_locally_modified="yes">
+<description>http://www.resistor.com/assets/pdf/2512std.pdf</description>
+<packageinstances>
+<packageinstance name="R2512"/>
+</packageinstances>
+</package3d>
 </packages3d>
 <symbols>
 <symbol name="CPOL-1" urn="urn:adsk.eagle:symbol:4855519/1" library_version="25" library_locally_modified="yes">
@@ -3061,6 +3695,18 @@ http://www.bccomponents.com/</description>
 <text x="2.1844" y="1.0922" size="1.27" layer="94" ratio="15" align="center">+</text>
 <text x="-1.651" y="-0.9906" size="1.27" layer="96" font="vector" rot="R180" align="center-left">&gt;VALUE</text>
 <text x="-1.524" y="0.762" size="0.762" layer="97" font="vector" align="center-right">&gt;PACKAGE</text>
+</symbol>
+<symbol name="R-EU-1" urn="urn:adsk.eagle:symbol:2539432/2" library_version="46" library_locally_modified="yes">
+<wire x1="-2.54" y1="-0.889" x2="2.54" y2="-0.889" width="0.254" layer="94"/>
+<wire x1="2.54" y1="0.889" x2="-2.54" y2="0.889" width="0.254" layer="94"/>
+<wire x1="2.54" y1="-0.889" x2="2.54" y2="0.889" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="-0.889" x2="-2.54" y2="0.889" width="0.254" layer="94"/>
+<text x="0" y="0" size="1.27" layer="95" align="center">&gt;NAME</text>
+<text x="-0.254" y="-2.032" size="0.762" layer="96" align="bottom-right">&gt;VALUE</text>
+<text x="-3.81" y="0.508" size="0.508" layer="95" align="center">&gt;PACKAGE</text>
+<text x="0.254" y="-2.032" size="0.762" layer="96">&gt;TOLERANCE</text>
+<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
 </symbol>
 </symbols>
 <devicesets>
@@ -3279,134 +3925,144 @@ http://www.bccomponents.com/</description>
 </device>
 </devices>
 </deviceset>
-</devicesets>
-</library>
-<library name="pinhead" urn="urn:adsk.eagle:library:2540341">
-<packages>
-<package name="1X02-PTH-2.54" urn="urn:adsk.eagle:footprint:2540357/1" library_version="30">
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="0.635" x2="-2.54" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="-1.905" y1="1.27" x2="-2.54" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="-0.635" x2="-1.905" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.2032" layer="21"/>
-<pad name="1" x="-1.27" y="0" drill="1" diameter="1.7" rot="R90"/>
-<pad name="2" x="1.27" y="0" drill="1" diameter="1.7" rot="R90"/>
-<text x="0" y="0" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="37"/>
-<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="37"/>
-</package>
-<package name="1X02-PTH-2" urn="urn:adsk.eagle:footprint:6503390/2" library_version="30">
-<pad name="1" x="-1" y="0" drill="0.8" diameter="1.4"/>
-<pad name="2" x="1" y="0" drill="0.8" diameter="1.4"/>
-<wire x1="-1.5" y1="1" x2="-0.5" y2="1" width="0.15" layer="21"/>
-<wire x1="-0.5" y1="1" x2="0" y2="0.5" width="0.15" layer="21"/>
-<wire x1="0" y1="-0.5" x2="-0.5" y2="-1" width="0.15" layer="21"/>
-<wire x1="-0.5" y1="-1" x2="-1.5" y2="-1" width="0.15" layer="21"/>
-<wire x1="-1.5" y1="-1" x2="-2" y2="-0.5" width="0.15" layer="21"/>
-<wire x1="-2" y1="-0.5" x2="-2" y2="0.5" width="0.15" layer="21"/>
-<wire x1="-2" y1="0.5" x2="-1.5" y2="1" width="0.15" layer="21"/>
-<wire x1="0.5" y1="1" x2="1.5" y2="1" width="0.15" layer="21"/>
-<wire x1="1.5" y1="1" x2="2" y2="0.5" width="0.15" layer="21"/>
-<wire x1="2" y1="-0.5" x2="1.5" y2="-1" width="0.15" layer="21"/>
-<wire x1="1.5" y1="-1" x2="0.5" y2="-1" width="0.15" layer="21"/>
-<wire x1="0.5" y1="-1" x2="0" y2="-0.5" width="0.15" layer="21"/>
-<wire x1="0" y1="0.5" x2="0.5" y2="1" width="0.15" layer="21"/>
-<wire x1="2" y1="-0.5" x2="2" y2="0.5" width="0.15" layer="21"/>
-<text x="0" y="1.6" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-<package name="1X02-PTH-2-FEMALE" urn="urn:adsk.eagle:footprint:6503391/1" library_version="30">
-<pad name="1" x="-1" y="0" drill="0.8" diameter="1.4"/>
-<pad name="2" x="1" y="0" drill="0.8" diameter="1.4"/>
-<wire x1="-0.5" y1="-1" x2="-2" y2="-1" width="0.15" layer="25"/>
-<wire x1="-2" y1="-1" x2="-2" y2="0.5" width="0.15" layer="25"/>
-<wire x1="-2" y1="0.5" x2="-2" y2="1" width="0.15" layer="21"/>
-<wire x1="-2" y1="1" x2="2" y2="1" width="0.15" layer="21"/>
-<wire x1="2" y1="1" x2="2" y2="-0.5" width="0.15" layer="21"/>
-<wire x1="2" y1="-0.5" x2="2" y2="-1" width="0.15" layer="21"/>
-<wire x1="2" y1="-1" x2="-0.5" y2="-1" width="0.15" layer="21"/>
-<text x="0" y="1.6" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
-</package>
-</packages>
-<packages3d>
-<package3d name="1X02-PTH-2.54" urn="urn:adsk.eagle:package:2540385/2" type="model" library_version="30">
-<packageinstances>
-<packageinstance name="1X02-PTH-2.54"/>
-</packageinstances>
-</package3d>
-<package3d name="1X02-PTH-2" urn="urn:adsk.eagle:package:6503394/4" type="model" library_version="30">
-<packageinstances>
-<packageinstance name="1X02-PTH-2"/>
-</packageinstances>
-</package3d>
-<package3d name="1X02-PTH-2-FEMALE" urn="urn:adsk.eagle:package:6503395/3" type="model" library_version="30">
-<packageinstances>
-<packageinstance name="1X02-PTH-2-FEMALE"/>
-</packageinstances>
-</package3d>
-</packages3d>
-<symbols>
-<symbol name="M02" urn="urn:adsk.eagle:symbol:2540349/1" library_version="30">
-<wire x1="6.35" y1="0" x2="0" y2="0" width="0.4064" layer="94"/>
-<wire x1="3.81" y1="5.08" x2="5.08" y2="5.08" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="2.54" x2="5.08" y2="2.54" width="0.6096" layer="94"/>
-<wire x1="0" y1="7.62" x2="0" y2="0" width="0.4064" layer="94"/>
-<wire x1="6.35" y1="0" x2="6.35" y2="7.62" width="0.4064" layer="94"/>
-<wire x1="0" y1="7.62" x2="6.35" y2="7.62" width="0.4064" layer="94"/>
-<text x="2.54" y="8.89" size="1.778" layer="95" font="vector" ratio="15" align="center">&gt;NAME</text>
-<pin name="1" x="7.62" y="2.54" visible="pin" length="short" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="2" x="7.62" y="5.08" visible="pin" length="short" direction="pas" swaplevel="1" rot="R180"/>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="PINHEAD_1X02" urn="urn:adsk.eagle:component:2540406/7" prefix="CON" library_version="30">
-<description>pinheader 2P</description>
+<deviceset name="R" urn="urn:adsk.eagle:component:2539478/9" prefix="R" uservalue="yes" library_version="46" library_locally_modified="yes">
 <gates>
-<gate name="G$1" symbol="M02" x="-2.54" y="0"/>
+<gate name="G$1" symbol="R-EU-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-2.54" package="1X02-PTH-2.54">
+<device name="-0402" package="R0402">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:2540385/2"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539456/2"/>
 </package3dinstances>
 <technologies>
-<technology name=""/>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="0402" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="0402" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
+</technology>
 </technologies>
 </device>
-<device name="-2" package="1X02-PTH-2">
+<device name="-0805" package="R0805">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:6503394/4"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539455/2"/>
 </package3dinstances>
 <technologies>
-<technology name=""/>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="0805" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="0805" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
+</technology>
 </technologies>
 </device>
-<device name="-2-FEMALE" package="1X02-PTH-2-FEMALE">
+<device name="-0603" package="R0603">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:6503395/3"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539454/2"/>
 </package3dinstances>
 <technologies>
-<technology name=""/>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="0603" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="0603" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-1206" package="R1206">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539464/2"/>
+</package3dinstances>
+<technologies>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="1206" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="1206" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-2512" package="R2512">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:4855216/2"/>
+</package3dinstances>
+<technologies>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="2512" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="2512" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
+</technology>
 </technologies>
 </device>
 </devices>
@@ -3573,127 +4229,127 @@ http://www.bccomponents.com/</description>
 </classes>
 <parts>
 <part name="+P2" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="5V" device=""/>
-<part name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
+<part name="PAD22" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
+<part name="PAD23" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
+<part name="PAD24" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD25" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD26" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD27" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD28" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD29" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD30" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD31" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD32" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD33" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD34" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD35" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD36" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD37" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD38" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD39" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD40" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD41" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD18" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD19" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD20" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD21" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD17" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD16" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD15" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD14" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD13" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD12" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD11" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD10" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD9" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD8" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD7" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD6" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/1">
+<part name="PAD5" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE-0.6" package3d_urn="urn:adsk.eagle:package:6513718/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
+<part name="PAD4" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
+<part name="PAD3" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
+<part name="PAD2" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" value="PAD-1X1.5">
+<part name="PAD1" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-1X1.5" package3d_urn="urn:adsk.eagle:package:7879127/1" value="PAD-1X1.5">
 <variant name="Basic" populate="no"/>
 </part>
 <part name="C10" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" deviceset="0.1µF" device="-0402" package3d_urn="urn:adsk.eagle:package:2539379/2" technology="-16V_10%_X7R" value="0.1µF"/>
@@ -3726,21 +4382,21 @@ http://www.bccomponents.com/</description>
 <part name="GND5" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="PGND" device="" value="PGND"/>
 <part name="+P6" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="VDC" device=""/>
 <part name="+P4" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="VDC" device=""/>
-<part name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5">
+<part name="PAD44" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="R4" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" deviceset="CURRENT_SHUNT_KELVIN" device="-2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" technology="-0.005R" value="5 mOhms"/>
+<part name="R4" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" deviceset="CURRENT_SHUNT_KELVIN" device="-2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" technology="-0.010R" value="10 mOhms"/>
 <part name="IC1" library="misc" library_urn="urn:adsk.eagle:library:5347860" deviceset="MCP9700" device="-SC70-5" package3d_urn="urn:adsk.eagle:package:7365869/3"/>
 <part name="C5" library="C_digikey" library_urn="urn:adsk.eagle:library:2539367" deviceset="0.1µF" device="-0402" package3d_urn="urn:adsk.eagle:package:2539379/2" technology="-16V_10%_X7R" value="0.1µF"/>
 <part name="R1" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="4R3" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-5%" value="4R3"/>
 <part name="R2" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="4R3" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-5%" value="4R3"/>
-<part name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5">
+<part name="PAD45" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="R10" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" deviceset="CURRENT_SHUNT_KELVIN" device="-2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" technology="-0.005R" value="5 mOhms"/>
+<part name="R10" library="SHUNT_RESISTORS" library_urn="urn:adsk.eagle:library:2644450" deviceset="CURRENT_SHUNT_KELVIN" device="-2512-KELVIN" package3d_urn="urn:adsk.eagle:package:3560627/3" technology="-0.010R" value="10 mOhms"/>
 <part name="R8" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="4R3" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-5%" value="4R3"/>
 <part name="R9" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="4R3" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-5%" value="4R3"/>
-<part name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/2" value="PAD-HOLE_1.5">
+<part name="PAD46" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-HOLE_1.5" package3d_urn="urn:adsk.eagle:package:3332368/3" value="PAD-HOLE_1.5">
 <variant name="Basic" populate="no"/>
 </part>
 <part name="R11" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="4R3" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-5%" value="4R3"/>
@@ -3785,9 +4441,6 @@ http://www.bccomponents.com/</description>
 <part name="C2" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="CPOL" device="-RADIAL_SIDE-8X21.5" package3d_urn="urn:adsk.eagle:package:7189333/3" value="180µF">
 <variant name="nocaps" populate="no"/>
 </part>
-<part name="CON3" library="pinhead" library_urn="urn:adsk.eagle:library:2540341" deviceset="PINHEAD_1X02" device="-2.54" package3d_urn="urn:adsk.eagle:package:2540385/2">
-<variant name="Basic" populate="no"/>
-</part>
 <part name="+P3" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="VDC" device=""/>
 <part name="+P1" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="VDC" device=""/>
 <part name="IC3" library="serial_interfaces" library_urn="urn:adsk.eagle:library:4770999" deviceset="TJA1051(X)/3" device="-SO8" package3d_urn="urn:adsk.eagle:package:4771007/3"/>
@@ -3820,8 +4473,15 @@ http://www.bccomponents.com/</description>
 <part name="LED3" library="myxa_masterlib" library_urn="urn:adsk.eagle:library:1040030" deviceset="LTST-C19HE1WT" device="" package3d_urn="urn:adsk.eagle:package:1040199/2">
 <variant name="Basic" populate="no"/>
 </part>
-<part name="R14" library="R_digikey" library_urn="urn:adsk.eagle:library:2539499" deviceset="1K" device="-0402" package3d_urn="urn:adsk.eagle:package:2539512/2" technology="-1%" value="1K"/>
+<part name="R14" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="R" device="-0402" package3d_urn="urn:adsk.eagle:package:2539456/2" technology="-1%" value="680R">
+<attribute name="AEC-Q" value="AEC-Q200"/>
+<attribute name="DIGIKEY#" value="CRCW0402680RFKEDDatasheet "/>
+<attribute name="MANF" value="Vishay Dale"/>
+<attribute name="MANF#" value="CRCW0402680RFKED"/>
+</part>
 <part name="GND25" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="PAD47" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-S-1.5" package3d_urn="urn:adsk.eagle:package:15477730/1"/>
+<part name="PAD48" library="PADS" library_urn="urn:adsk.eagle:library:3188696" deviceset="PAD" device="-S-1.5" package3d_urn="urn:adsk.eagle:package:15477730/1"/>
 </parts>
 <sheets>
 <sheet>
@@ -3869,10 +4529,39 @@ as close as possible to the power transistors.</text>
 <text x="134.62" y="160.02" size="2.54" layer="97">Place close to power mosfets</text>
 <text x="233.68" y="38.1" size="1.778" layer="91">https://www.digikey.com/product-detail/en/united-chemi-con/EKZN500ELL181MH20D/565-4066-ND/4843876</text>
 <wire x1="289.56" y1="134.62" x2="289.56" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="289.56" y1="63.5" x2="368.3" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="368.3" y1="63.5" x2="375.92" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
+<wire x1="289.56" y1="63.5" x2="375.92" y2="63.5" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="375.92" y1="63.5" x2="375.92" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
 <wire x1="375.92" y1="134.62" x2="289.56" y2="134.62" width="0.1524" layer="97" style="shortdash"/>
+<text x="20.32" y="30.48" size="1.27" layer="91" font="vector" ratio="15" align="center">DC power, W</text>
+<text x="38.1" y="30.48" size="1.27" layer="91" font="vector" ratio="15" align="center">Phase current, I</text>
+<text x="58.42" y="30.48" size="1.27" layer="91" font="vector" ratio="15" align="center">Total losses, W</text>
+<text x="81.28" y="30.48" size="1.27" layer="91" font="vector" ratio="15" align="center">Efficiency, %</text>
+<text x="20.32" y="25.4" size="1.27" layer="91" font="vector" ratio="15" align="center">100</text>
+<text x="20.32" y="22.86" size="1.27" layer="91" font="vector" ratio="15" align="center">150</text>
+<text x="20.32" y="20.32" size="1.27" layer="91" font="vector" ratio="15" align="center">200</text>
+<text x="20.32" y="17.78" size="1.27" layer="91" font="vector" ratio="15" align="center">250</text>
+<text x="20.32" y="15.24" size="1.27" layer="91" font="vector" ratio="15" align="center">300</text>
+<text x="50.8" y="10.16" size="1.27" layer="91" font="vector" ratio="15" align="center">The table is valid for 26.4 V supply voltage which is discharched 8S battery</text>
+<text x="38.1" y="25.4" size="1.27" layer="91" font="vector" ratio="15" align="center">4.8</text>
+<text x="58.42" y="25.4" size="1.27" layer="91" font="vector" ratio="15" align="center">1.7</text>
+<text x="81.28" y="25.4" size="1.27" layer="91" font="vector" ratio="15" align="center">98.3</text>
+<text x="38.1" y="22.86" size="1.27" layer="91" font="vector" ratio="15" align="center">7.2</text>
+<text x="58.42" y="22.86" size="1.27" layer="91" font="vector" ratio="15" align="center">3</text>
+<text x="81.28" y="22.86" size="1.27" layer="91" font="vector" ratio="15" align="center">98</text>
+<text x="38.1" y="20.32" size="1.27" layer="91" font="vector" ratio="15" align="center">9.6</text>
+<text x="58.42" y="20.32" size="1.27" layer="91" font="vector" ratio="15" align="center">4.5</text>
+<text x="81.28" y="20.32" size="1.27" layer="91" font="vector" ratio="15" align="center">97.7</text>
+<text x="38.1" y="17.78" size="1.27" layer="91" font="vector" ratio="15" align="center">12</text>
+<text x="58.42" y="17.78" size="1.27" layer="91" font="vector" ratio="15" align="center">6.3</text>
+<text x="81.28" y="17.78" size="1.27" layer="91" font="vector" ratio="15" align="center">97.5</text>
+<text x="38.1" y="15.24" size="1.27" layer="91" font="vector" ratio="15" align="center">14.4</text>
+<text x="58.42" y="15.24" size="1.27" layer="91" font="vector" ratio="15" align="center">8.4</text>
+<text x="81.28" y="15.24" size="1.27" layer="91" font="vector" ratio="15" align="center">97.2</text>
+<text x="53.34" y="35.56" size="1.27" layer="91" font="vector" ratio="15" align="center">Power losses for different power levels</text>
+<text x="63.5" y="111.76" size="1.778" layer="91" font="vector" ratio="15" align="center-left">R14 sets overcurrent protection trip level. 
+680R sets ir arount 35A, which is 2.5 times 
+higher than maximum phase current for 300W DC power 
+when running on discharged 8S battery</text>
 </plain>
 <instances>
 <instance part="+P2" gate="G$1" x="45.72" y="238.76" smashed="yes">
@@ -4109,17 +4798,17 @@ as close as possible to the power transistors.</text>
 <attribute name="LAST_DATE_TIME" x="344.17" y="10.16" size="2.286" layer="94"/>
 <attribute name="SHEET" x="357.505" y="5.08" size="2.54" layer="94"/>
 </instance>
-<instance part="GND3" gate="G$1" x="142.24" y="223.52" smashed="yes">
-<attribute name="VALUE" x="142.24" y="222.25" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
+<instance part="GND3" gate="G$1" x="142.24" y="220.98" smashed="yes">
+<attribute name="VALUE" x="142.24" y="219.71" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="GND5" gate="G$1" x="157.48" y="223.52" smashed="yes">
-<attribute name="VALUE" x="157.48" y="222.25" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
+<instance part="GND5" gate="G$1" x="157.48" y="220.98" smashed="yes">
+<attribute name="VALUE" x="157.48" y="219.71" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="+P6" gate="G$1" x="157.48" y="236.22" smashed="yes">
-<attribute name="VALUE" x="157.48" y="239.776" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="+P6" gate="G$1" x="157.48" y="238.76" smashed="yes">
+<attribute name="VALUE" x="157.48" y="242.316" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="+P4" gate="G$1" x="142.24" y="236.22" smashed="yes">
-<attribute name="VALUE" x="142.24" y="239.776" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="+P4" gate="G$1" x="142.24" y="238.76" smashed="yes">
+<attribute name="VALUE" x="142.24" y="242.316" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
 <instance part="PAD44" gate="G$1" x="241.3" y="220.98" smashed="yes" rot="MR0">
 <attribute name="NAME" x="241.3" y="222.25" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
@@ -4286,19 +4975,16 @@ as close as possible to the power transistors.</text>
 <attribute name="VALUE" x="158.4706" y="229.489" size="1.27" layer="96" font="vector" rot="R270" align="center-left"/>
 <attribute name="PACKAGE" x="156.718" y="229.616" size="0.762" layer="97" font="vector" rot="R90" align="center-right"/>
 </instance>
-<instance part="GND4" gate="G$1" x="149.86" y="223.52" smashed="yes">
-<attribute name="VALUE" x="149.86" y="222.25" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
+<instance part="GND4" gate="G$1" x="149.86" y="220.98" smashed="yes">
+<attribute name="VALUE" x="149.86" y="219.71" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="+P5" gate="G$1" x="149.86" y="236.22" smashed="yes">
-<attribute name="VALUE" x="149.86" y="239.776" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="+P5" gate="G$1" x="149.86" y="238.76" smashed="yes">
+<attribute name="VALUE" x="149.86" y="242.316" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
 <instance part="C2" gate="G$1" x="149.86" y="231.14" smashed="yes" rot="R90">
 <attribute name="NAME" x="150.9014" y="232.791" size="1.27" layer="95" font="vector" rot="R90" align="center-left"/>
 <attribute name="VALUE" x="150.8506" y="229.489" size="1.27" layer="96" font="vector" rot="R270" align="center-left"/>
 <attribute name="PACKAGE" x="149.098" y="229.616" size="0.762" layer="97" font="vector" rot="R90" align="center-right"/>
-</instance>
-<instance part="CON3" gate="G$1" x="370.84" y="147.32" smashed="yes" rot="MR0">
-<attribute name="NAME" x="368.3" y="156.21" size="1.778" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
 <instance part="+P3" gate="G$1" x="119.38" y="236.22" smashed="yes">
 <attribute name="VALUE" x="119.38" y="239.776" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
@@ -4319,12 +5005,12 @@ as close as possible to the power transistors.</text>
 <attribute name="PACKAGE" x="162.052" y="184.912" size="0.508" layer="97" rot="R90" align="center"/>
 <attribute name="VOLTAGE" x="162.814" y="180.594" size="0.762" layer="96" rot="R270" align="bottom-center"/>
 </instance>
-<instance part="J2" gate="G$1" x="337.82" y="144.78" smashed="yes"/>
-<instance part="GND18" gate="G$1" x="342.9" y="139.7" smashed="yes">
-<attribute name="VALUE" x="342.9" y="137.668" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="J2" gate="G$1" x="335.28" y="144.78" smashed="yes"/>
+<instance part="GND18" gate="G$1" x="340.36" y="139.7" smashed="yes">
+<attribute name="VALUE" x="340.36" y="137.668" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="FD2" gate="G$1" x="15.24" y="12.7" smashed="yes" rot="R270"/>
-<instance part="FD1" gate="G$1" x="15.24" y="22.86" smashed="yes" rot="R270"/>
+<instance part="FD2" gate="G$1" x="12.7" y="66.04" smashed="yes" rot="R270"/>
+<instance part="FD1" gate="G$1" x="12.7" y="73.66" smashed="yes" rot="R270"/>
 <instance part="J1" gate="G$1" x="320.04" y="144.78" smashed="yes" rot="MR0"/>
 <instance part="GND13" gate="G$1" x="314.96" y="139.7" smashed="yes">
 <attribute name="VALUE" x="314.96" y="138.43" size="1.27" layer="97" font="vector" ratio="15" align="center"/>
@@ -4351,14 +5037,20 @@ as close as possible to the power transistors.</text>
 <instance part="LED3" gate="G$1" x="241.3" y="121.92" smashed="yes" rot="R270">
 <attribute name="NAME" x="257.556" y="116.84" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
 </instance>
-<instance part="R14" gate="G$1" x="33.02" y="116.84" smashed="yes" rot="MR180">
-<attribute name="NAME" x="33.02" y="116.84" size="1.27" layer="95" rot="MR180" align="center"/>
-<attribute name="VALUE" x="32.766" y="118.872" size="0.762" layer="96" rot="MR180" align="bottom-right"/>
-<attribute name="PACKAGE" x="29.21" y="116.332" size="0.508" layer="95" rot="MR180" align="center"/>
-<attribute name="TOLERANCE" x="33.274" y="118.872" size="0.762" layer="96" rot="MR180"/>
+<instance part="R14" gate="G$1" x="25.4" y="116.84" smashed="yes" rot="MR180">
+<attribute name="NAME" x="25.4" y="116.84" size="1.27" layer="95" rot="MR180" align="center"/>
+<attribute name="VALUE" x="25.146" y="118.872" size="0.762" layer="96" rot="MR180" align="bottom-right"/>
+<attribute name="PACKAGE" x="21.59" y="116.332" size="0.508" layer="95" rot="MR180" align="center"/>
+<attribute name="TOLERANCE" x="25.654" y="118.872" size="0.762" layer="96" rot="MR180"/>
 </instance>
-<instance part="GND25" gate="1" x="22.86" y="111.76" smashed="yes">
-<attribute name="VALUE" x="22.86" y="110.49" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+<instance part="GND25" gate="1" x="17.78" y="111.76" smashed="yes">
+<attribute name="VALUE" x="17.78" y="110.49" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+</instance>
+<instance part="PAD47" gate="G$1" x="370.84" y="149.86" smashed="yes" rot="MR0">
+<attribute name="NAME" x="370.84" y="151.13" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
+</instance>
+<instance part="PAD48" gate="G$1" x="370.84" y="157.48" smashed="yes" rot="MR0">
+<attribute name="NAME" x="370.84" y="158.75" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
 </instances>
 <busses>
@@ -4434,9 +5126,9 @@ as close as possible to the power transistors.</text>
 <pinref part="PAD14" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
-<pinref part="CON3" gate="G$1" pin="2"/>
-<wire x1="363.22" y1="152.4" x2="360.68" y2="152.4" width="0.1524" layer="91"/>
-<label x="360.68" y="152.4" size="1.27" layer="95" rot="MR0" xref="yes"/>
+<pinref part="PAD48" gate="G$1" pin="P$1"/>
+<wire x1="368.3" y1="157.48" x2="365.76" y2="157.48" width="0.1524" layer="91"/>
+<label x="365.76" y="157.48" size="1.27" layer="95" font="vector" ratio="15" rot="MR0" xref="yes"/>
 </segment>
 </net>
 <net name="PHASE_A_GND" class="0">
@@ -4716,9 +5408,8 @@ as close as possible to the power transistors.</text>
 </net>
 <net name="OVERCURRENT_PROTECT_ADJ" class="0">
 <segment>
-<wire x1="45.72" y1="116.84" x2="43.18" y2="116.84" width="0.1524" layer="91"/>
 <pinref part="PAD13" gate="G$1" pin="P$1"/>
-<wire x1="43.18" y1="116.84" x2="38.1" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="45.72" y1="116.84" x2="30.48" y2="116.84" width="0.1524" layer="91"/>
 <pinref part="R14" gate="G$1" pin="2"/>
 </segment>
 </net>
@@ -4850,7 +5541,6 @@ as close as possible to the power transistors.</text>
 <pinref part="GND15" gate="1" pin="GND"/>
 <wire x1="327.66" y1="144.78" x2="327.66" y2="142.24" width="0.1524" layer="91"/>
 <pinref part="J2" gate="G$1" pin="P$1"/>
-<wire x1="332.74" y1="144.78" x2="335.28" y2="144.78" width="0.1524" layer="91"/>
 <wire x1="332.74" y1="144.78" x2="327.66" y2="144.78" width="0.1524" layer="91"/>
 <junction x="327.66" y="144.78"/>
 </segment>
@@ -4874,9 +5564,9 @@ as close as possible to the power transistors.</text>
 </segment>
 <segment>
 <wire x1="360.68" y1="147.32" x2="360.68" y2="149.86" width="0.1524" layer="91"/>
-<pinref part="CON3" gate="G$1" pin="1"/>
-<wire x1="360.68" y1="149.86" x2="363.22" y2="149.86" width="0.1524" layer="91"/>
+<wire x1="360.68" y1="149.86" x2="368.3" y2="149.86" width="0.1524" layer="91"/>
 <pinref part="GND21" gate="1" pin="GND"/>
+<pinref part="PAD47" gate="G$1" pin="P$1"/>
 </segment>
 <segment>
 <pinref part="C4" gate="G$1" pin="2"/>
@@ -4885,8 +5575,8 @@ as close as possible to the power transistors.</text>
 <wire x1="162.56" y1="175.26" x2="162.56" y2="177.8" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<wire x1="22.86" y1="114.3" x2="22.86" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="22.86" y1="116.84" x2="27.94" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="114.3" x2="17.78" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="116.84" x2="20.32" y2="116.84" width="0.1524" layer="91"/>
 <pinref part="R14" gate="G$1" pin="1"/>
 <pinref part="GND25" gate="1" pin="GND"/>
 </segment>
@@ -4930,9 +5620,9 @@ as close as possible to the power transistors.</text>
 </segment>
 <segment>
 <pinref part="GND18" gate="G$1" pin="GNDD"/>
-<wire x1="342.9" y1="142.24" x2="342.9" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="340.36" y1="142.24" x2="340.36" y2="144.78" width="0.1524" layer="91"/>
 <pinref part="J2" gate="G$1" pin="P$2"/>
-<wire x1="342.9" y1="144.78" x2="340.36" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="340.36" y1="144.78" x2="337.82" y2="144.78" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="CAN1_VDD" class="0">
@@ -5006,12 +5696,12 @@ as close as possible to the power transistors.</text>
 <net name="PGND" class="0">
 <segment>
 <pinref part="GND3" gate="G$1" pin="PGND"/>
-<wire x1="142.24" y1="226.06" x2="142.24" y2="228.6" width="0.1524" layer="91"/>
+<wire x1="142.24" y1="223.52" x2="142.24" y2="228.6" width="0.1524" layer="91"/>
 <pinref part="C1" gate="G$1" pin="-"/>
 </segment>
 <segment>
 <pinref part="GND5" gate="G$1" pin="PGND"/>
-<wire x1="157.48" y1="226.06" x2="157.48" y2="228.6" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="223.52" x2="157.48" y2="228.6" width="0.1524" layer="91"/>
 <pinref part="C3" gate="G$1" pin="-"/>
 </segment>
 <segment>
@@ -5056,7 +5746,7 @@ as close as possible to the power transistors.</text>
 </segment>
 <segment>
 <pinref part="GND4" gate="G$1" pin="PGND"/>
-<wire x1="149.86" y1="226.06" x2="149.86" y2="228.6" width="0.1524" layer="91"/>
+<wire x1="149.86" y1="223.52" x2="149.86" y2="228.6" width="0.1524" layer="91"/>
 <pinref part="C2" gate="G$1" pin="-"/>
 </segment>
 <segment>
@@ -5094,12 +5784,12 @@ as close as possible to the power transistors.</text>
 </net>
 <net name="VDC" class="1">
 <segment>
-<wire x1="157.48" y1="236.22" x2="157.48" y2="233.68" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="238.76" x2="157.48" y2="233.68" width="0.1524" layer="91"/>
 <pinref part="+P6" gate="G$1" pin="VDC"/>
 <pinref part="C3" gate="G$1" pin="+"/>
 </segment>
 <segment>
-<wire x1="142.24" y1="236.22" x2="142.24" y2="233.68" width="0.1524" layer="91"/>
+<wire x1="142.24" y1="238.76" x2="142.24" y2="233.68" width="0.1524" layer="91"/>
 <pinref part="+P4" gate="G$1" pin="VDC"/>
 <pinref part="C1" gate="G$1" pin="+"/>
 </segment>
@@ -5138,7 +5828,7 @@ as close as possible to the power transistors.</text>
 <wire x1="302.26" y1="231.14" x2="302.26" y2="233.68" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<wire x1="149.86" y1="236.22" x2="149.86" y2="233.68" width="0.1524" layer="91"/>
+<wire x1="149.86" y1="238.76" x2="149.86" y2="233.68" width="0.1524" layer="91"/>
 <pinref part="+P5" gate="G$1" pin="VDC"/>
 <pinref part="C2" gate="G$1" pin="+"/>
 </segment>
@@ -5260,6 +5950,26 @@ as close as possible to the power transistors.</text>
 <wire x1="271.78" y1="104.14" x2="271.78" y2="99.06" width="0.1524" layer="91"/>
 <wire x1="248.92" y1="104.14" x2="271.78" y2="104.14" width="0.1524" layer="91"/>
 <junction x="271.78" y="104.14"/>
+</segment>
+</net>
+<net name="N$1" class="0">
+<segment>
+<wire x1="12.7" y1="33.02" x2="12.7" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="27.94" x2="12.7" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="12.7" x2="27.94" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="12.7" x2="48.26" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="12.7" x2="71.12" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="12.7" x2="91.44" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="33.02" x2="71.12" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="33.02" x2="48.26" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="33.02" x2="27.94" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="33.02" x2="12.7" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="33.02" x2="91.44" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="27.94" x2="91.44" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="33.02" x2="71.12" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="33.02" x2="48.26" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="33.02" x2="27.94" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="27.94" x2="91.44" y2="27.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 </nets>

--- a/tools/camjob_panel_4l.cam
+++ b/tools/camjob_panel_4l.cam
@@ -97,7 +97,7 @@
                     },
                     "filename_format": "/gerber/%N/%NAME.gbr",
                     "layers": [
-                        20
+                        49
                     ],
                     "milling": true,
                     "name": "profile",
@@ -195,6 +195,21 @@
                     "name": "silkscreen bottom",
                     "polarity": "positive",
                     "type": "gerber_layer"
+                },
+                {
+                    "board_outline": false,
+                    "config": {
+                        "description": "Other",
+                        "file_function": "Other"
+                    },
+                    "filename_format": "/gerber/%N/%NAME.gbr",
+                    "layers": [
+                        46
+                    ],
+                    "milling": false,
+                    "name": "milling",
+                    "polarity": "positive",
+                    "type": "gerber_layer"
                 }
             ],
             "version": "RS274X"
@@ -212,12 +227,12 @@
                         "PTH": true,
                         "VIA": true
                     },
-                    "filename_format": "/gerber/%N/drills.xln",
+                    "filename_format": "/gerber/%N/%NAME.gbr",
                     "layers": {
                         "from": 1,
                         "to": 16
                     },
-                    "name": "Excellon",
+                    "name": "drills",
                     "type": "excellon"
                 }
             ]
@@ -226,12 +241,6 @@
             "filename_prefix": "CAMOutputs/Assembly",
             "output_type": "assembly",
             "outputs": [
-                {
-                    "filename_format": "/PnP/%N/PnP_%BOARDSIDE",
-                    "name": "Pick and Place",
-                    "output_format": "txt",
-                    "type": "pick_and_place"
-                }
             ]
         },
         {
@@ -241,7 +250,7 @@
             ]
         }
     ],
-    "timestamp": "2020-06-03T13:27:21",
+    "timestamp": "2020-06-03T16:25:20",
     "type": "EAGLE CAM job",
     "units": "metric",
     "version": "8.6.1"


### PR DESCRIPTION
- Current shunts replaced (5 mOhms replaced with 10 mOhms)
- Overcurrent protection added. Itrip is ~35 A
- RCPWM th connector replaced with smd solder pads
- Some design notes added to the schematic